### PR TITLE
feat: add content sorting functionality for content categorization

### DIFF
--- a/frontend/.astro/content.d.ts
+++ b/frontend/.astro/content.d.ts
@@ -234,6 +234,6 @@ declare module 'astro:content' {
 		LiveContentConfig['collections'][C]['loader']
 	>;
 
-	export type ContentConfig = typeof import("./../src/content.config.js");
+	export type ContentConfig = typeof import("../src/content.config.js");
 	export type LiveContentConfig = never;
 }

--- a/frontend/src/components/content/EventsPage.tsx
+++ b/frontend/src/components/content/EventsPage.tsx
@@ -6,7 +6,7 @@ import { MasonryCard } from '../ui/MasonryCard';
 import { useFilterState } from '../../lib/filter/useFilterState';
 import { filterItems } from '../../lib/filter/filterUtils';
 import { calculateFacets } from '../../lib/filter/facetUtils';
-import { eventsFilters } from '../../lib/filter/filterConfig';
+import { eventsFilters, sortFilters } from '../../lib/filter/filterConfig';
 import type { Locale } from '../../lib/i18n';
 import { getFilterLabel } from '../../lib/i18n/filterTranslations';
 
@@ -19,13 +19,15 @@ interface EventsPageProps {
 export default function EventsPage({ initialItems, lang, initialFilters = {} }: EventsPageProps) {
     const { filters, setFilter, resetFilters } = useFilterState(initialFilters);
 
+    const combinedFilters = useMemo(() => [...eventsFilters, ...sortFilters], []);
+
     const filteredItems = useMemo(() => {
-        return filterItems(initialItems, filters, { filters: eventsFilters });
-    }, [initialItems, filters]);
+        return filterItems(initialItems, filters, { filters: combinedFilters });
+    }, [initialItems, filters, combinedFilters]);
 
     const facetConfig = useMemo(() => {
-        return calculateFacets(initialItems, eventsFilters);
-    }, [initialItems]);
+        return calculateFacets(initialItems, combinedFilters);
+    }, [initialItems, combinedFilters]);
 
     const filterTitle = lang === 'zh' ? '筛选' : lang === 'de' ? 'Filter' : 'Filters';
 

--- a/frontend/src/components/content/GearPage.tsx
+++ b/frontend/src/components/content/GearPage.tsx
@@ -6,7 +6,7 @@ import { MasonryCard } from '../ui/MasonryCard';
 import { useFilterState } from '../../lib/filter/useFilterState';
 import { filterItems } from '../../lib/filter/filterUtils';
 import { calculateFacets } from '../../lib/filter/facetUtils';
-import { gearFilters } from '../../lib/filter/filterConfig';
+import { gearFilters, sortFilters } from '../../lib/filter/filterConfig';
 import type { Locale } from '../../lib/i18n';
 import { getFilterLabel } from '../../lib/i18n/filterTranslations';
 
@@ -19,13 +19,15 @@ interface GearPageProps {
 export default function GearPage({ initialItems, lang, initialFilters = {} }: GearPageProps) {
     const { filters, setFilter, resetFilters } = useFilterState(initialFilters);
 
+    const combinedFilters = useMemo(() => [...gearFilters, ...sortFilters], []);
+
     const filteredItems = useMemo(() => {
-        return filterItems(initialItems, filters, { filters: gearFilters });
-    }, [initialItems, filters]);
+        return filterItems(initialItems, filters, { filters: combinedFilters });
+    }, [initialItems, filters, combinedFilters]);
 
     const facetConfig = useMemo(() => {
-        return calculateFacets(initialItems, gearFilters);
-    }, [initialItems]);
+        return calculateFacets(initialItems, combinedFilters);
+    }, [initialItems, combinedFilters]);
 
     const filterTitle = lang === 'zh' ? '筛选' : lang === 'de' ? 'Filter' : 'Filters';
 

--- a/frontend/src/components/content/MediaPage.tsx
+++ b/frontend/src/components/content/MediaPage.tsx
@@ -6,7 +6,7 @@ import { MasonryCard } from '../ui/MasonryCard';
 import { useFilterState } from '../../lib/filter/useFilterState';
 import { filterItems } from '../../lib/filter/filterUtils';
 import { calculateFacets } from '../../lib/filter/facetUtils';
-import { mediaFilters } from '../../lib/filter/filterConfig';
+import { mediaFilters, sortFilters } from '../../lib/filter/filterConfig';
 import type { Locale } from '../../lib/i18n';
 
 interface MediaPageProps {
@@ -20,14 +20,16 @@ import { getFilterLabel } from '../../lib/i18n/filterTranslations';
 export default function MediaPage({ initialItems, lang, initialFilters = {} }: MediaPageProps) {
     const { filters, setFilter, resetFilters } = useFilterState(initialFilters);
 
+    const combinedFilters = useMemo(() => [...mediaFilters, ...sortFilters], []);
+
     const filteredItems = useMemo(() => {
-        return filterItems(initialItems, filters, { filters: mediaFilters });
-    }, [initialItems, filters]);
+        return filterItems(initialItems, filters, { filters: combinedFilters });
+    }, [initialItems, filters, combinedFilters]);
 
     // Calculate facets based on initial items (Global Counts) to ensure options are populated
     const facetConfig = useMemo(() => {
-        return calculateFacets(initialItems, mediaFilters);
-    }, [initialItems]);
+        return calculateFacets(initialItems, combinedFilters);
+    }, [initialItems, combinedFilters]);
 
     const filterTitle = lang === 'zh' ? '筛选' : lang === 'de' ? 'Filter' : 'Filters';
 

--- a/frontend/src/components/content/RoutesPage.tsx
+++ b/frontend/src/components/content/RoutesPage.tsx
@@ -6,7 +6,7 @@ import { MasonryCard } from '../ui/MasonryCard';
 import { useFilterState } from '../../lib/filter/useFilterState';
 import { filterItems } from '../../lib/filter/filterUtils';
 import { calculateFacets } from '../../lib/filter/facetUtils';
-import { routesFilters } from '../../lib/filter/filterConfig';
+import { routesFilters, sortFilters } from '../../lib/filter/filterConfig';
 import type { Locale } from '../../lib/i18n';
 import { getFilterLabel } from '../../lib/i18n/filterTranslations';
 
@@ -19,13 +19,15 @@ interface RoutesPageProps {
 export default function RoutesPage({ initialItems, lang, initialFilters = {} }: RoutesPageProps) {
     const { filters, setFilter, resetFilters } = useFilterState(initialFilters);
 
+    const combinedFilters = useMemo(() => [...routesFilters, ...sortFilters], []);
+
     const filteredItems = useMemo(() => {
-        return filterItems(initialItems, filters, { filters: routesFilters });
-    }, [initialItems, filters]);
+        return filterItems(initialItems, filters, { filters: combinedFilters });
+    }, [initialItems, filters, combinedFilters]);
 
     const facetConfig = useMemo(() => {
-        return calculateFacets(initialItems, routesFilters);
-    }, [initialItems]);
+        return calculateFacets(initialItems, combinedFilters);
+    }, [initialItems, combinedFilters]);
 
     const filterTitle = lang === 'zh' ? '筛选' : lang === 'de' ? 'Filter' : 'Filters';
 

--- a/frontend/src/components/content/TrainingPage.tsx
+++ b/frontend/src/components/content/TrainingPage.tsx
@@ -6,7 +6,7 @@ import { MasonryCard } from '../ui/MasonryCard';
 import { useFilterState } from '../../lib/filter/useFilterState';
 import { filterItems } from '../../lib/filter/filterUtils';
 import { calculateFacets } from '../../lib/filter/facetUtils';
-import { trainingFilters } from '../../lib/filter/filterConfig';
+import { trainingFilters, sortFilters } from '../../lib/filter/filterConfig';
 import type { Locale } from '../../lib/i18n';
 import { getFilterLabel } from '../../lib/i18n/filterTranslations';
 
@@ -19,13 +19,15 @@ interface TrainingPageProps {
 export default function TrainingPage({ initialItems, lang, initialFilters = {} }: TrainingPageProps) {
     const { filters, setFilter, resetFilters } = useFilterState(initialFilters);
 
+    const combinedFilters = useMemo(() => [...trainingFilters, ...sortFilters], []);
+
     const filteredItems = useMemo(() => {
-        return filterItems(initialItems, filters, { filters: trainingFilters });
-    }, [initialItems, filters]);
+        return filterItems(initialItems, filters, { filters: combinedFilters });
+    }, [initialItems, filters, combinedFilters]);
 
     const facetConfig = useMemo(() => {
-        return calculateFacets(initialItems, trainingFilters);
-    }, [initialItems]);
+        return calculateFacets(initialItems, combinedFilters);
+    }, [initialItems, combinedFilters]);
 
     const filterTitle = lang === 'zh' ? '筛选' : lang === 'de' ? 'Filter' : 'Filters';
 

--- a/frontend/src/components/filter/FilterCheckboxGroup.tsx
+++ b/frontend/src/components/filter/FilterCheckboxGroup.tsx
@@ -38,19 +38,23 @@ export function FilterCheckboxGroup({ field, options, selectedValues, onChange, 
 
     return (
         <div className="filter-checkbox-group">
-            {visibleOptions.map((option) => (
-                <label key={String(option.value)} className="checkbox-label">
-                    <input
-                        type="checkbox"
-                        className="checkbox-input"
-                        value={String(option.value)}
-                        checked={selectedValues.includes(String(option.value))}
-                        onChange={(e) => handleChange(String(option.value), (e.target as HTMLInputElement).checked)}
-                    />
-                    <span className="checkbox-text">{getFilterLabel(field, option.value, lang)}</span>
-                    <span className="checkbox-count">({option.count || 0})</span>
-                </label>
-            ))}
+            {visibleOptions.map((option) => {
+                const isSortField = field === 'sort';
+                return (
+                    <label key={String(option.value)} className="checkbox-label">
+                        <input
+                            type={isSortField ? "radio" : "checkbox"}
+                            className={isSortField ? "radio-input" : "checkbox-input"}
+                            name={`filter-${field}`}
+                            value={String(option.value)}
+                            checked={selectedValues.includes(String(option.value))}
+                            onChange={(e) => handleChange(String(option.value), (e.target as HTMLInputElement).checked)}
+                        />
+                        <span className="checkbox-text">{getFilterLabel(field, option.value, lang)}</span>
+                        {!isSortField && <span className="checkbox-count">({option.count || 0})</span>}
+                    </label>
+                );
+            })}
 
             {hasMore && (
                 <button

--- a/frontend/src/components/filter/FilterPanel.tsx
+++ b/frontend/src/components/filter/FilterPanel.tsx
@@ -114,14 +114,30 @@ export function FilterPanel({
                             });
                         }
 
+                        // Translate section title if it's 'sort'
+                        let sectionTitle = def.label;
+                        if (def.key === 'sort') {
+                            sectionTitle = lang === 'zh' ? '排序' : lang === 'de' ? 'Sortieren' : 'Sort By';
+                        }
+
                         return (
-                            <FilterSection key={def.key} title={def.label}>
+                            <FilterSection key={def.key} title={sectionTitle}>
                                 {def.type === 'multiselect' || def.type === 'select' ? (
                                     <FilterCheckboxGroup
                                         field={def.key}
                                         options={options}
-                                        selectedValues={(value as string[]) || []}
-                                        onChange={onFilterChange}
+                                        selectedValues={
+                                            Array.isArray(value) ? value :
+                                            value !== undefined ? [value as string] : []
+                                        }
+                                        onChange={(field, newValues) => {
+                                            if (def.type === 'select') {
+                                                // For 'select', treat it as a single value or toggle
+                                                onFilterChange(field, newValues.length > 0 ? newValues[newValues.length - 1] : undefined);
+                                            } else {
+                                                onFilterChange(field, newValues);
+                                            }
+                                        }}
                                         lang={lang}
                                     />
                                 ) : def.type === 'range' ? (

--- a/frontend/src/lib/filter/filterConfig.ts
+++ b/frontend/src/lib/filter/filterConfig.ts
@@ -159,6 +159,20 @@ export const eventsFilters: FilterDefinition[] = [
     }
 ];
 
+export const sortFilters: FilterDefinition[] = [
+    {
+        key: 'sort',
+        label: 'Sort By',
+        type: 'select',
+        options: [
+            { value: 'date-desc', label: 'Newest First' },
+            { value: 'date-asc', label: 'Oldest First' },
+            { value: 'name-asc', label: 'Name (A-Z)' },
+            { value: 'name-desc', label: 'Name (Z-A)' }
+        ]
+    }
+];
+
 export const allFilterConfigs = {
     media: mediaFilters,
     gear: gearFilters,

--- a/frontend/src/lib/filter/filterUtils.ts
+++ b/frontend/src/lib/filter/filterUtils.ts
@@ -14,10 +14,16 @@ export function filterItems<T extends Record<string, any>>(
     filters: FilterState,
     config: FilterConfig
 ): T[] {
-    return items.filter((item) => {
+    let result = items.filter((item) => {
         // Iterate through each configured filter
         for (const filterDef of config.filters) {
             const filterKey = filterDef.key;
+
+            // Skip the sort filter because it is not an attribute match
+            if (filterKey === 'sort') {
+                continue;
+            }
+
             const filterValue = filters[filterKey];
 
             // Skip if no filter value is set
@@ -68,6 +74,36 @@ export function filterItems<T extends Record<string, any>>(
 
         return true;
     });
+
+    // Apply sorting logic if the 'sort' filter key is defined in state
+    if (filters['sort']) {
+        const sortValue = Array.isArray(filters['sort']) ? filters['sort'][0] : filters['sort'];
+        result = result.sort((a, b) => {
+            if (sortValue === 'date-desc') {
+                const dateA = new Date(getFilterableValue(a, 'date') || 0).getTime();
+                const dateB = new Date(getFilterableValue(b, 'date') || 0).getTime();
+                return dateB - dateA;
+            }
+            if (sortValue === 'date-asc') {
+                const dateA = new Date(getFilterableValue(a, 'date') || 0).getTime();
+                const dateB = new Date(getFilterableValue(b, 'date') || 0).getTime();
+                return dateA - dateB;
+            }
+            if (sortValue === 'name-asc') {
+                const nameA = String(getFilterableValue(a, 'title') || getFilterableValue(a, 'name') || '').toLowerCase();
+                const nameB = String(getFilterableValue(b, 'title') || getFilterableValue(b, 'name') || '').toLowerCase();
+                return nameA.localeCompare(nameB);
+            }
+            if (sortValue === 'name-desc') {
+                const nameA = String(getFilterableValue(a, 'title') || getFilterableValue(a, 'name') || '').toLowerCase();
+                const nameB = String(getFilterableValue(b, 'title') || getFilterableValue(b, 'name') || '').toLowerCase();
+                return nameB.localeCompare(nameA);
+            }
+            return 0;
+        });
+    }
+
+    return result;
 }
 
 /**

--- a/frontend/src/lib/i18n/filterTranslations.ts
+++ b/frontend/src/lib/i18n/filterTranslations.ts
@@ -42,6 +42,12 @@ export const FILTER_TRANSLATIONS: Record<string, Record<string, Record<string, s
         'alps-austria': { zh: '奥地利阿尔卑斯', de: 'Österreichische Alpen', en: 'Austrian Alps' },
         'alps-italy': { zh: '多洛米蒂', de: 'Dolomiten', en: 'Dolomites' },
         'island-spain': { zh: '西班牙海岛', de: 'Spanische Inseln', en: 'Spanish Islands' }
+    },
+    sort: {
+        'date-desc': { zh: '最新发布', de: 'Neueste zuerst', en: 'Newest First' },
+        'date-asc': { zh: '最早发布', de: 'Älteste zuerst', en: 'Oldest First' },
+        'name-asc': { zh: '名称 (A-Z)', de: 'Name (A-Z)', en: 'Name (A-Z)' },
+        'name-desc': { zh: '名称 (Z-A)', de: 'Name (Z-A)', en: 'Name (Z-A)' }
     }
 };
 


### PR DESCRIPTION
Closes #18 by adding a sorting functionality to all content categorization pages (Routes, Gear, Training, Media, Events). Users can now sort content by Date (Newest/Oldest) and Name (A-Z/Z-A). The sorting option integrates seamlessly with the existing filter panel.

---
*PR created automatically by Jules for task [6477870869512978786](https://jules.google.com/task/6477870869512978786) started by @GenLI3202*