### PR TITLE
Phase 4/tier2 tier3 fixes

### DIFF
--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -12,7 +12,11 @@ from sqlalchemy.orm import Session
 from database import get_db
 from models import Event, RSVP, Subscriber
 from routes.auth import get_current_admin
-from services.email import send_cancellation_email, send_broadcast_email
+from services.email import (
+    send_cancellation_email,
+    send_broadcast_email,
+    send_registrant_notification_email,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -242,6 +246,60 @@ def export_rsvps_csv(
     output.close()
 
     return csv_content.encode("utf-8")
+
+
+# ── Notify Registrants ───────────────────────────────────────
+
+@router.post("/api/admin/events/{event_id}/notify")
+def notify_registrants(
+    event_id: int,
+    db: Session = Depends(get_db),
+    _admin: dict = Depends(get_current_admin),
+) -> dict:
+    """
+    Send an event notification email to all confirmed and waitlisted registrants.
+
+    Skips cancelled RSVPs. Failed sends are logged but do not abort the batch.
+    Returns a summary: {sent, skipped, failed}.
+
+    Requires admin authentication.
+    """
+    event = db.query(Event).filter(Event.id == event_id).first()
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    rsvps = (
+        db.query(RSVP)
+        .filter(RSVP.event_id == event_id)
+        .order_by(RSVP.created_at)
+        .all()
+    )
+
+    sent = 0
+    skipped = 0
+    failed = 0
+
+    for rsvp in rsvps:
+        if rsvp.status == "cancelled":
+            skipped += 1
+            continue
+        try:
+            send_registrant_notification_email(
+                user_email=rsvp.email,
+                user_name=rsvp.name,
+                event_title=event.title,
+                event_date=event.event_date,
+                event_location=event.location,
+                event_slug=event.slug,
+                view_token=rsvp.view_token or "",
+                lang="en",
+            )
+            sent += 1
+        except Exception as e:
+            logger.error("Registrant notification failed for %s: %s", rsvp.email, e)
+            failed += 1
+
+    return {"sent": sent, "skipped": skipped, "failed": failed}
 
 
 # ── Broadcast Email ───────────────────────────────────────────

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -280,6 +280,103 @@ def send_broadcast_email(
         return {"status": "error", "message": str(e)}
 
 
+def send_registrant_notification_email(
+    user_email: str,
+    user_name: str,
+    event_title: str,
+    event_date: Optional[datetime] = None,
+    event_location: Optional[str] = None,
+    event_slug: str = "",
+    view_token: str = "",
+    lang: str = "en",
+) -> dict:
+    """Send an event update/reminder notification to an event registrant."""
+    if not settings.RESEND_API_KEY:
+        logger.debug("Skipping registrant notification (no RESEND_API_KEY): %s", user_email)
+        return {"status": "skipped", "reason": "no_api_key"}
+
+    date_str = event_date.strftime("%Y-%m-%d %H:%M") if event_date else ""
+    frontend_url = settings.PUBLIC_FRONTEND_URL or "https://www.accross-cc.de"
+    event_link = (
+        f"{frontend_url}/{lang}/events/{event_slug}?token={view_token}"
+        if event_slug and view_token
+        else f"{frontend_url}/{lang}/events/{event_slug}"
+        if event_slug
+        else frontend_url
+    )
+
+    templates = {
+        "zh": {
+            "subject": f"活动提醒: {event_title}",
+            "body": (
+                f"<p>您好 {user_name}，</p>"
+                f"<p>以下是您已报名活动的最新信息：</p>"
+                f"<ul>"
+                f"<li><strong>活动：</strong>{event_title}</li>"
+                + (f"<li><strong>时间：</strong>{date_str}</li>" if date_str else "")
+                + (f"<li><strong>地点：</strong>{event_location}</li>" if event_location else "")
+                + f"</ul>"
+                f'<p><a href="{event_link}" style="background:#2A5CA6;color:white;padding:8px 16px;'
+                f'border-radius:4px;text-decoration:none;font-weight:600;">查看活动详情 →</a></p>'
+                f"<p>—— ACC ClubHub 团队</p>"
+            ),
+        },
+        "en": {
+            "subject": f"Event Reminder: {event_title}",
+            "body": (
+                f"<p>Hello {user_name},</p>"
+                f"<p>Here is an update about the event you registered for:</p>"
+                f"<ul>"
+                f"<li><strong>Event:</strong> {event_title}</li>"
+                + (f"<li><strong>Date:</strong> {date_str}</li>" if date_str else "")
+                + (f"<li><strong>Location:</strong> {event_location}</li>" if event_location else "")
+                + f"</ul>"
+                f'<p><a href="{event_link}" style="background:#2A5CA6;color:white;padding:8px 16px;'
+                f'border-radius:4px;text-decoration:none;font-weight:600;">View Event →</a></p>'
+                f"<p>—— ACC ClubHub Team</p>"
+            ),
+        },
+        "de": {
+            "subject": f"Veranstaltungserinnerung: {event_title}",
+            "body": (
+                f"<p>Hallo {user_name},</p>"
+                f"<p>Hier ist eine Aktualisierung zur Veranstaltung, für die Sie sich angemeldet haben:</p>"
+                f"<ul>"
+                f"<li><strong>Veranstaltung:</strong> {event_title}</li>"
+                + (f"<li><strong>Datum:</strong> {date_str}</li>" if date_str else "")
+                + (f"<li><strong>Ort:</strong> {event_location}</li>" if event_location else "")
+                + f"</ul>"
+                f'<p><a href="{event_link}" style="background:#2A5CA6;color:white;padding:8px 16px;'
+                f'border-radius:4px;text-decoration:none;font-weight:600;">Veranstaltung ansehen →</a></p>'
+                f"<p>—— ACC ClubHub Team</p>"
+            ),
+        },
+    }
+
+    template = templates.get(lang, templates["en"])
+    html_body = (
+        f'<div style="font-family:Arial,sans-serif;max-width:600px;">'
+        f'<h2 style="color:#2A5CA6;">🚴 {template["subject"]}</h2>'
+        f"{template['body']}"
+        f"</div>"
+    )
+
+    params = {
+        "from": "ACC ClubHub <noreply@events.accross-cc.de>",
+        "to": [user_email],
+        "subject": template["subject"],
+        "html": html_body,
+    }
+
+    try:
+        return resend.Emails.send(params)
+    except Exception as e:
+        logger.error(
+            "Failed to send registrant notification to %s: %s", user_email, e, exc_info=True,
+        )
+        return {"status": "error", "message": str(e)}
+
+
 def send_waitlist_email(
     user_email: str,
     user_name: str,

--- a/backend/tests/test_notify_registrants.py
+++ b/backend/tests/test_notify_registrants.py
@@ -1,0 +1,146 @@
+"""
+TDD tests for POST /api/admin/events/{event_id}/notify  (#73)
+
+Expected behaviour:
+1. Sends one email per confirmed + waitlisted RSVP
+2. Skips cancelled RSVPs (counted in 'skipped')
+3. Failed sends are logged but do not abort the batch
+4. Returns a summary: {sent, skipped, failed}
+5. Returns 404 when event_id is unknown
+6. Requires admin authentication (handled by fixture override)
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+from models import Event, RSVP
+import datetime
+
+
+# ── helpers ───────────────────────────────────────────────────
+
+def _notify(client, event_id: int):
+    return client.post(f"/api/admin/events/{event_id}/notify", json={})
+
+
+def _make_rsvp(db, event_id: int, email: str, name: str, status: str = "confirmed"):
+    rsvp = RSVP(
+        event_id=event_id,
+        email=email,
+        name=name,
+        status=status,
+        privacy_accepted=True,
+        view_token=f"tok-{email.split('@')[0]}",
+    )
+    db.add(rsvp)
+    db.flush()
+    return rsvp
+
+
+# ── tests ─────────────────────────────────────────────────────
+
+class TestNotifyBasic:
+    def test_notify_unknown_event_returns_404(self, client, db):
+        resp = _notify(client, 9999)
+        assert resp.status_code == 404
+
+    def test_notify_no_rsvps_returns_zero_sent(self, client, db, sample_event):
+        with patch("routes.admin.send_registrant_notification_email",
+                   return_value={"status": "sent"}):
+            resp = _notify(client, sample_event.id)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["sent"] == 0
+        assert body["skipped"] == 0
+        assert body["failed"] == 0
+
+    def test_notify_sends_to_confirmed_rsvps(self, client, db, sample_event):
+        _make_rsvp(db, sample_event.id, "alice@test.com", "Alice", "confirmed")
+        db.commit()
+
+        with patch("routes.admin.send_registrant_notification_email") as mock_email:
+            mock_email.return_value = {"status": "sent"}
+            resp = _notify(client, sample_event.id)
+
+        assert resp.status_code == 200
+        assert resp.json()["sent"] == 1
+        assert mock_email.call_count == 1
+
+    def test_notify_sends_to_waitlisted_rsvps(self, client, db, sample_event):
+        _make_rsvp(db, sample_event.id, "alice@test.com", "Alice", "confirmed")
+        _make_rsvp(db, sample_event.id, "bob@test.com", "Bob", "waitlist")
+        db.commit()
+
+        with patch("routes.admin.send_registrant_notification_email") as mock_email:
+            mock_email.return_value = {"status": "sent"}
+            resp = _notify(client, sample_event.id)
+
+        assert resp.json()["sent"] == 2
+        assert mock_email.call_count == 2
+
+    def test_notify_skips_cancelled_rsvps(self, client, db, sample_event):
+        _make_rsvp(db, sample_event.id, "active@test.com", "Active", "confirmed")
+        _make_rsvp(db, sample_event.id, "gone@test.com", "Gone", "cancelled")
+        db.commit()
+
+        with patch("routes.admin.send_registrant_notification_email") as mock_email:
+            mock_email.return_value = {"status": "sent"}
+            resp = _notify(client, sample_event.id)
+
+        body = resp.json()
+        assert body["sent"] == 1
+        assert body["skipped"] == 1
+        assert mock_email.call_count == 1
+
+    def test_notify_returns_summary_counts(self, client, db, sample_event):
+        _make_rsvp(db, sample_event.id, "a@test.com", "A", "confirmed")
+        _make_rsvp(db, sample_event.id, "b@test.com", "B", "waitlist")
+        _make_rsvp(db, sample_event.id, "c@test.com", "C", "cancelled")
+        db.commit()
+
+        with patch("routes.admin.send_registrant_notification_email",
+                   return_value={"status": "sent"}):
+            resp = _notify(client, sample_event.id)
+
+        body = resp.json()
+        assert body["sent"] == 2
+        assert body["skipped"] == 1
+        assert body["failed"] == 0
+
+
+class TestNotifyResilience:
+    def test_failed_send_does_not_abort_batch(self, client, db, sample_event):
+        _make_rsvp(db, sample_event.id, "fail@test.com", "Fail", "confirmed")
+        _make_rsvp(db, sample_event.id, "ok@test.com", "Ok", "confirmed")
+        db.commit()
+
+        def flaky_send(**kwargs):
+            if kwargs["user_email"] == "fail@test.com":
+                raise Exception("SMTP error")
+            return {"status": "sent"}
+
+        with patch("routes.admin.send_registrant_notification_email",
+                   side_effect=flaky_send):
+            resp = _notify(client, sample_event.id)
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["sent"] == 1
+        assert body["failed"] == 1
+
+
+class TestNotifyEmailArgs:
+    def test_notify_passes_correct_args_to_email(self, client, db, sample_event):
+        rsvp = _make_rsvp(db, sample_event.id, "alice@test.com", "Alice", "confirmed")
+        db.commit()
+
+        with patch("routes.admin.send_registrant_notification_email") as mock_email:
+            mock_email.return_value = {"status": "sent"}
+            _notify(client, sample_event.id)
+
+        call_kwargs = mock_email.call_args.kwargs
+        assert call_kwargs["user_email"] == "alice@test.com"
+        assert call_kwargs["user_name"] == "Alice"
+        assert call_kwargs["event_title"] == sample_event.title
+        assert call_kwargs["event_slug"] == sample_event.slug
+        assert call_kwargs["view_token"] == rsvp.view_token

--- a/frontend/src/pages/dashboard/events/[id].astro
+++ b/frontend/src/pages/dashboard/events/[id].astro
@@ -188,6 +188,7 @@ const statusClass: Record<string, string> = {
       .error { background: #ffebe9; border: 1px solid #ff818266; padding: 1rem; border-radius: 6px; color: #cf222e; margin-bottom: 1rem; }
       .empty { text-align: center; padding: 3rem; color: #57606a; }
       .email-cell { font-family: monospace; font-size: 0.85rem; }
+      #notify-status { font-size: 0.85rem; margin-left: 0.5rem; }
     </style>
   </head>
   <body>
@@ -240,6 +241,10 @@ const statusClass: Record<string, string> = {
             >
               Export CSV
             </a>
+            <button class="action-btn" id="notify-btn">
+              📧 Notify Registrants
+            </button>
+            <span id="notify-status"></span>
           </div>
 
           <div style="height: 1.5rem;"></div>
@@ -341,6 +346,35 @@ const statusClass: Record<string, string> = {
         btn.addEventListener("click", () => {
           cancelRsvp(btn.dataset.rsvpId, btn.dataset.rsvpName, btn);
         });
+      });
+
+      // Notify all confirmed + waitlisted registrants
+      document.getElementById("notify-btn")?.addEventListener("click", async () => {
+        const btn = document.getElementById("notify-btn");
+        const status = document.getElementById("notify-status");
+        if (!confirm("Send a notification email to all confirmed and waitlisted registrants?")) return;
+
+        btn.disabled = true;
+        status.textContent = "Sending…";
+        status.style.color = "#57606a";
+
+        try {
+          const res = await fetch(`/api/admin/events/${id}/notify`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({}),
+          });
+          const data = await res.json();
+          if (!res.ok) throw new Error(data.detail || `${res.status}`);
+          status.textContent = `✓ Sent: ${data.sent}  Skipped: ${data.skipped}  Failed: ${data.failed}`;
+          status.style.color = "#1a7f37";
+        } catch (e) {
+          status.textContent = `✗ ${e.message}`;
+          status.style.color = "#cf222e";
+        } finally {
+          btn.disabled = false;
+        }
       });
     </script>
   </body>

--- a/frontend/src/pages/dashboard/subscribers/index.astro
+++ b/frontend/src/pages/dashboard/subscribers/index.astro
@@ -153,13 +153,17 @@ function formatDate(dateStr: string | null): string {
         align-items: center;
         flex-wrap: wrap;
       }
-      .broadcast-form input {
+      .broadcast-form select {
         padding: 0.4rem 0.75rem;
         border: 1px solid #d0d7de;
         border-radius: 6px;
         font-size: 0.85rem;
-        width: 220px;
+        min-width: 260px;
+        background: white;
+        color: #24292f;
+        cursor: pointer;
       }
+      .broadcast-form select:disabled { opacity: 0.6; cursor: not-allowed; }
       .btn {
         display: inline-block;
         padding: 0.4rem 0.9rem;
@@ -188,7 +192,9 @@ function formatDate(dateStr: string | null): string {
       <div class="header">
         <h1>Subscribers</h1>
         <div class="broadcast-form">
-          <input id="broadcast-slug" type="text" placeholder="event-slug" />
+          <select id="broadcast-slug" disabled>
+            <option value="">Loading events…</option>
+          </select>
           <button class="btn" id="broadcast-btn">📢 Broadcast Event</button>
           <span id="broadcast-status"></span>
         </div>
@@ -283,12 +289,64 @@ function formatDate(dateStr: string | null): string {
         });
       });
 
+      // Populate the event dropdown with upcoming/ongoing events
+      (async () => {
+        const select = document.getElementById("broadcast-slug");
+        try {
+          const res = await fetch(`${apiUrl}/api/admin/events`, {
+            credentials: "include",
+          });
+          if (!res.ok) throw new Error(`${res.status}`);
+          const events = await res.json();
+
+          const today = new Date();
+          today.setHours(0, 0, 0, 0);
+
+          const upcoming = events.filter((e) => {
+            if (!e.event_date) return false;
+            return new Date(e.event_date) >= today;
+          });
+
+          select.innerHTML = "";
+
+          if (upcoming.length === 0) {
+            const opt = document.createElement("option");
+            opt.value = "";
+            opt.textContent = "No upcoming events";
+            opt.disabled = true;
+            select.appendChild(opt);
+          } else {
+            const placeholder = document.createElement("option");
+            placeholder.value = "";
+            placeholder.textContent = "— select an event —";
+            placeholder.disabled = true;
+            placeholder.selected = true;
+            select.appendChild(placeholder);
+
+            upcoming
+              .sort((a, b) => new Date(a.event_date) - new Date(b.event_date))
+              .forEach((e) => {
+                const opt = document.createElement("option");
+                opt.value = e.slug;
+                const dateLabel = new Date(e.event_date).toLocaleDateString("en-GB", {
+                  year: "numeric", month: "short", day: "numeric",
+                });
+                opt.textContent = `${e.title} (${dateLabel})`;
+                select.appendChild(opt);
+              });
+          }
+          select.disabled = false;
+        } catch (err) {
+          select.innerHTML = "<option value=\"\" disabled>Failed to load events</option>";
+        }
+      })();
+
       // Broadcast email to all active subscribers
       document.getElementById("broadcast-btn")?.addEventListener("click", async () => {
         const slug = document.getElementById("broadcast-slug").value.trim();
         const status = document.getElementById("broadcast-status");
         const btn = document.getElementById("broadcast-btn");
-        if (!slug) { alert("Please enter an event slug."); return; }
+        if (!slug) { alert("Please select an event."); return; }
         if (!confirm(`Broadcast event "${slug}" to all active subscribers?`)) return;
 
         btn.disabled = true;


### PR DESCRIPTION
Here's a summary of what was delivered:

  ---
  Issue #73 — Notify event registrants

  - TDD: 8 tests written first (all RED), then implementation made them GREEN.
  Full suite 32/32.
  - send_registrant_notification_email() added to email.py — multilingual
  (zh/en/de), includes personalised event link with view_token.
  - POST /api/admin/events/{event_id}/notify added to admin.py — sends to
  confirmed + waitlisted RSVPs, skips cancelled, returns {sent, skipped,
  failed}.
  - dashboard/events/[id].astro — "📧 Notify Registrants" button added to the
  actions bar with inline status feedback.

  Issue #74 — Broadcast slug input → dropdown

  - subscribers/index.astro — <input type="text"> replaced with <select>.
  - On page load, fetches /api/admin/events, filters to event_date >= today,
  sorts chronologically, and populates the dropdown. Past events are excluded.
  Handles empty/error states gracefully.
  - Broadcast flow (confirm → POST) is unchanged; only the slug source changed.

  3 commits on phase-4/tier2-tier3-fixes: d2d9d49, a59a253, f0941b0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Notify Registrants" button on event dashboard to send notifications to registrants with counts of sent, skipped, and failed emails
  * Updated broadcast form with dropdown selector for upcoming events (auto-loads and filters by date)

* **Tests**
  * Added comprehensive test suite for registrant notification feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->