### PR TITLE
feat(homepage): splash screen intro animation + section polish

### DIFF
--- a/docs/rebuild_plan/implemented/homepage-redesign.md
+++ b/docs/rebuild_plan/implemented/homepage-redesign.md
@@ -1,0 +1,207 @@
+Here is a draft plan to refine:
+
+# Homepage Redesign Plan: ACC ClubHub (11.Apr.2026)
+
+## Context
+
+### Why this change
+
+ACC ClubHub's current homepage treats all 5 content pillars (Events, Media, Gear, Training, Routes) as equal-weight cards in a grid. This creates two problems:
+
+1. **Identity crisis** — a new visitor can't answer "what is this site?" in 3 seconds
+2. **No clear call-to-action** — the grid is a directory, not a story
+
+### Positioning Clarity
+
+From the 2026 planning doc, ACC's identity actually IS clear — the homepage just doesn't reflect it:
+
+```
+ACC = 骑行社区(核心) + 专业内容(差异化) + 工具服务(留存)
+```
+
+* **Core product** : Organized rides & events (what members DO together)
+* **Growth engine** : Professional content (why people DISCOVER ACC)
+* **Differentiation** : European perspective on cycling knowledge (why ACC, not others)
+* **Retention tools** : Route database, Strava/Komoot integration
+
+The homepage should tell this story in order: **感受氛围 → 参与骑行 → 探索内容 → 深入了解**
+
+### Design Direction (User-approved)
+
+Hybrid of Plan B (event-first banner) + Plan A (editorial alternating sections):
+
+* Hero: Keep existing (cycling photo + tagline + CTA)
+* Next Ride Banner: Prominent upcoming event strip (Plan B)
+* Content Pillars: Full-width alternating editorial sections (Plan A)
+* Remove: Card grid + watermark background
+
+### Current State Constraint
+
+Content is sparse (AI templates). Design must look complete NOW and scale when real content arrives in 2 months.
+
+---
+
+## Implementation Plan
+
+### Commit 1: Add i18n keys for homepage sections
+
+ **File** : `frontend/src/lib/i18n.ts`
+
+Add homepage-specific translation keys to all 3 locale objects (zh/en/de):
+
+* `home.nextRide` — "下一次骑行" / "Next Ride" / "Nächste Ausfahrt"
+* `home.noUpcoming` — "更多活动即将公布" / "More rides coming soon" / "Weitere Ausfahrten folgen"
+* `home.events.title/subtitle/cta` — Events section text
+* `home.media.title/subtitle/cta` — Media section text
+* `home.gear.title/subtitle/cta` — Gear section text
+* `home.training.title/subtitle/cta` — Training section text
+* `home.routes.title/subtitle/cta` — Routes section text
+* `home.comingSoon` — "内容筹备中" / "Coming Soon" / "Demnächst"
+* `home.viewAll` — "查看全部 →" / "View All →" / "Alle ansehen →"
+
+This also removes the inline ternary chains currently in `index.astro`.
+
+---
+
+### Commit 2: Create NextRideBanner component
+
+ **New file** : `frontend/src/components/home/NextRideBanner.astro`
+
+ **Props** : `event: CollectionEntry<'events'> | null`, `lang: Locale`
+
+ **Behavior** :
+
+* If `event` exists: show date (locale-formatted), title, location, event type badge, CTA link to event detail page
+* If `event` is null: show "more rides coming soon" fallback
+* No API call for registration count in v1 (keep it pure static)
+
+ **Layout** :
+
+* Full-width strip using CSS breakout: `width: 100vw; margin-left: calc(50% - 50vw)`
+* Inner container: `max-width: var(--max-width); margin: 0 auto`
+* Background: `var(--color-bg-secondary)` with subtle top border accent
+* Horizontal layout at desktop (info left, CTA right), stacks on mobile
+* Scoped `<style>` block (matches existing component pattern)
+
+ **Data source** : Content collection `events`, filtered by `splitEvents()` from `frontend/src/lib/events/eventHelpers.ts`
+
+---
+
+### Commit 3: Create PillarSection component
+
+ **New file** : `frontend/src/components/home/PillarSection.astro`
+
+ **Props** :
+
+```ts
+interface Props {
+  title: string;
+  subtitle: string;
+  ctaLabel: string;
+  ctaHref: string;
+  imageUrl: string;
+  imageAlt: string;
+  imagePosition: 'left' | 'right';  // alternates per section
+  alternate: boolean;                // alternating bg color
+  items?: Array<{ title: string; href: string; meta?: string }>;
+  comingSoon?: string;               // fallback when items is empty
+}
+```
+
+ **Layout** :
+
+* Full-width breakout (same CSS pattern as NextRideBanner)
+* 2-column grid at desktop (`1fr 1fr`), stacks on mobile (image on top)
+* `imagePosition` controls CSS `order` to alternate image/text sides
+* `alternate` toggles between `var(--color-bg-canvas)` and `var(--color-bg-secondary)`
+* Image: `loading="lazy"`, `border-radius: var(--radius-aero)`, `object-fit: cover`
+* Text side: h2 title, subtitle paragraph, optional featured item links (max 2-3), CTA link
+* If no `items` AND `comingSoon` is set: show styled "coming soon" message instead of empty space
+* Scoped `<style>` block
+* Responsive breakpoint at 768px
+
+---
+
+### Commit 4: Rewrite homepage
+
+ **File** : `frontend/src/pages/[lang]/index.astro`
+
+ **Frontmatter data fetching** :
+
+```
+getCollection('events') → filter by lang, exclude drafts → splitEvents() → heroEvent (nearest future)
+getCollection('media')  → filter by lang → sort by date desc → slice(0, 2) → featured media items
+getCollection('routes') → filter by lang → slice(0, 2) → featured route items
+gear/training: empty arrays (content sparse, will show "coming soon")
+```
+
+ **Template structure** :
+
+```
+<BaseLayout>
+  <section slot="hero"> ... (keep existing hero, use i18n keys) </section>
+
+  <NextRideBanner event={heroEvent} lang={lang} />
+
+  <PillarSection title="慕城日常" imagePosition="left"  alternate={false} items={upcoming[0:2]} />
+  <PillarSection title="车影骑踪" imagePosition="right" alternate={true}  items={media[0:2]} />
+  <PillarSection title="器械知识" imagePosition="left"  alternate={false} comingSoon="..." />
+  <PillarSection title="科学训练" imagePosition="right" alternate={true}  comingSoon="..." />
+  <PillarSection title="骑行路线库" imagePosition="left" alternate={false} items={routes[0:2]} />
+</BaseLayout>
+```
+
+ **What gets removed** :
+
+* The `sections` array with inline ternary i18n chains
+* The `.hub-grid` div and all `.hub-card` elements
+* The watermark `::before` pseudo-element styles
+* All `.hub-grid` and `.hub-card` CSS rules (scoped in current `<style>`)
+
+**Image assignments** (from existing `/images/uploads/`):
+
+* Events: `rr120_2026_group_turn.jpg`
+* Media: `DSC04622.jpg`
+* Gear: `buy_canyon.webp`
+* Training: `RR120-SONNTAG-cPIARAZZI-20.jpg`
+* Routes: `ivan-bandura-Vdv_3HmV-tk-unsplash.jpg`
+
+---
+
+### Commit 5: Clean up orphaned global CSS (if any)
+
+Check `frontend/src/styles/global.css` for any `.hub-grid` / `.hub-card` rules that live outside the scoped `<style>` block. Remove if found. (From my read, all hub-grid styles are scoped inside `index.astro`, so this commit may be a no-op.)
+
+---
+
+## Files Modified
+
+| File                                                  | Action                                      |
+| ----------------------------------------------------- | ------------------------------------------- |
+| `frontend/src/lib/i18n.ts`                          | Add ~30 homepage translation keys           |
+| `frontend/src/components/home/NextRideBanner.astro` | **New**— event strip component       |
+| `frontend/src/components/home/PillarSection.astro`  | **New**— editorial section component |
+| `frontend/src/pages/[lang]/index.astro`             | Rewrite template + remove card grid         |
+| `frontend/src/styles/global.css`                    | Remove orphaned hub-grid rules (if any)     |
+
+## Existing Code to Reuse
+
+| What                                     | Where                                       |
+| ---------------------------------------- | ------------------------------------------- |
+| `splitEvents()`                        | `frontend/src/lib/events/eventHelpers.ts` |
+| `t()`,`Locale`,`ui`dict            | `frontend/src/lib/i18n.ts`                |
+| `getLangFromEntry()`                   | `frontend/src/lib/i18n.ts`                |
+| CSS variables (colors, spacing, shadows) | `frontend/src/styles/variables.css`       |
+| BaseLayout hero slot                     | `frontend/src/layouts/BaseLayout.astro`   |
+| Hero section styles                      | Keep as-is from current `index.astro`     |
+
+## Verification
+
+1. **3-locale check** : Visit `/zh`, `/en`, `/de` — all text from i18n, no raw keys
+2. **Dark mode** : Toggle theme — all sections have correct contrast
+3. **Mobile (375px)** : Sections stack, images scale, banner readable
+4. **Empty state** : Remove all events → NextRideBanner shows fallback, no crash
+5. **Performance** : Hero preloaded, all pillar images `loading="lazy"`
+6. **Links** : Every CTA navigates to correct section page
+7. **Build** : `npm run build` passes without errors
+8. **No regressions** : Events page (`/zh/events`) still works (uses its own components)

--- a/frontend/src/components/home/SplashScreen.astro
+++ b/frontend/src/components/home/SplashScreen.astro
@@ -1,0 +1,139 @@
+---
+// SplashScreen.astro — ACC brand intro animation, homepage only
+// Shows once per browser session via sessionStorage
+---
+
+<div class="splash" id="acc-splash" aria-hidden="true">
+    <div class="splash-bg-logo">
+        <img
+            src="/images/transparent_red_logo.png"
+            alt=""
+            aria-hidden="true"
+            draggable="false"
+        />
+    </div>
+    <div class="splash-content">
+        <h1 class="splash-name">ACC ClubHub</h1>
+        <p class="splash-tagline">Ride free, ride together.</p>
+    </div>
+    <div class="splash-progress">
+        <div class="splash-progress-bar"></div>
+    </div>
+</div>
+
+<style>
+    .splash {
+        position: fixed;
+        inset: 0;
+        z-index: 9999;
+        background: var(--color-bg-canvas);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        pointer-events: none;
+        /* JS controls fade-out; start fully visible */
+        opacity: 1;
+        transition: opacity 0.5s ease;
+    }
+
+    .splash-bg-logo {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        overflow: hidden;
+    }
+
+    .splash-bg-logo img {
+        width: min(65vw, 560px);
+        height: auto;
+        opacity: 0;
+        transform: scale(0.92);
+        animation: logo-breathe 2s ease forwards;
+        user-select: none;
+    }
+
+    .splash-content {
+        position: relative;
+        z-index: 1;
+        text-align: center;
+        animation: content-in 0.4s ease forwards;
+    }
+
+    .splash-name {
+        font-family: var(--font-heading);
+        font-size: clamp(2.5rem, 7vw, 4.5rem);
+        font-weight: 700;
+        color: var(--color-accent);
+        letter-spacing: -0.03em;
+        line-height: 1;
+        margin: 0;
+    }
+
+    .splash-tagline {
+        font-family: var(--font-body);
+        font-size: clamp(0.9rem, 2vw, 1.1rem);
+        color: var(--color-text-secondary);
+        margin-top: 0.6rem;
+        letter-spacing: 0.02em;
+        animation: content-in 0.4s 0.15s ease both;
+    }
+
+    .splash-progress {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 3px;
+        background: var(--color-border);
+        overflow: hidden;
+    }
+
+    .splash-progress-bar {
+        height: 100%;
+        width: 0%;
+        background: var(--color-accent);
+        animation: progress-fill 1.7s linear forwards;
+    }
+
+    @keyframes logo-breathe {
+        0%   { opacity: 0;    transform: scale(0.92); }
+        25%  { opacity: 0.1;  transform: scale(1.0);  }
+        70%  { opacity: 0.12; transform: scale(1.02); }
+        100% { opacity: 0.08; transform: scale(1.05); }
+    }
+
+    @keyframes content-in {
+        from { opacity: 0; transform: translateY(8px); }
+        to   { opacity: 1; transform: translateY(0);   }
+    }
+
+    @keyframes progress-fill {
+        from { width: 0%; }
+        to   { width: 100%; }
+    }
+</style>
+
+<script>
+    (function () {
+        const splash = document.getElementById("acc-splash");
+        if (!splash) return;
+
+        // Only show once per browser session
+        if (sessionStorage.getItem("acc-splash-shown")) {
+            splash.remove();
+            return;
+        }
+
+        sessionStorage.setItem("acc-splash-shown", "1");
+
+        // Fade out after 1.7s, remove after fade completes
+        setTimeout(function () {
+            splash.style.opacity = "0";
+            setTimeout(function () {
+                splash.remove();
+            }, 500);
+        }, 1700);
+    })();
+</script>

--- a/frontend/src/components/home/SplashScreen.astro
+++ b/frontend/src/components/home/SplashScreen.astro
@@ -4,7 +4,7 @@
 ---
 
 <div class="splash" id="acc-splash" aria-hidden="true">
-    <!-- Logo: top, prominent, heartbeat animation -->
+    <!-- Wheel: rolls in from left, decelerates to center -->
     <div class="splash-logo">
         <img
             src="/images/transparent_red_logo.png"
@@ -14,7 +14,7 @@
         />
     </div>
 
-    <!-- Text: below logo, no overlap -->
+    <!-- Text: fades in after wheel settles -->
     <div class="splash-content">
         <h1 class="splash-name">ACC ClubHub</h1>
         <p class="splash-tagline">Ride free, ride together.</p>
@@ -36,28 +36,33 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        gap: 1.5rem;
+        gap: 1.25rem;
         pointer-events: none;
         opacity: 1;
         transition: opacity 0.5s ease;
     }
 
-    /* Logo — in flow, above text */
+    /* Wheel: rolls in from left */
     .splash-logo {
         display: flex;
         align-items: center;
         justify-content: center;
+        /* clip horizontal overflow so wheel enters cleanly */
+        overflow: hidden;
+        width: 100%;
     }
 
     .splash-logo img {
-        width: min(42vw, 320px);
+        width: min(40vw, 300px);
         height: auto;
-        opacity: 0;
         user-select: none;
-        animation: logo-in 0.5s ease forwards, logo-heartbeat 1.4s 0.5s ease forwards;
+        /* start transparent, off-screen left */
+        opacity: 0;
+        transform: translateX(-50vw) rotate(0deg);
+        animation: wheel-roll-in 0.9s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
     }
 
-    /* Text — below logo */
+    /* Text: fades in after wheel settles */
     .splash-content {
         text-align: center;
     }
@@ -71,7 +76,7 @@
         line-height: 1;
         margin: 0;
         opacity: 0;
-        animation: content-in 0.4s 0.3s ease forwards;
+        animation: content-in 0.35s 0.75s ease forwards;
     }
 
     .splash-tagline {
@@ -81,7 +86,7 @@
         margin-top: 0.4rem;
         letter-spacing: 0.02em;
         opacity: 0;
-        animation: content-in 0.4s 0.5s ease forwards;
+        animation: content-in 0.35s 0.95s ease forwards;
     }
 
     /* Progress bar — pinned to bottom */
@@ -102,23 +107,30 @@
         animation: progress-fill 1.7s linear forwards;
     }
 
-    /* Logo: fade in → heartbeat (lub-dub double-pulse) */
-    @keyframes logo-in {
-        from { opacity: 0; transform: scale(0.9); }
-        to   { opacity: 0.38; transform: scale(1); }
-    }
-
-    @keyframes logo-heartbeat {
-        0%   { opacity: 0.38; transform: scale(1);    }
-        12%  { opacity: 0.45; transform: scale(1.07); }  /* lub */
-        22%  { opacity: 0.38; transform: scale(0.99); }
-        34%  { opacity: 0.44; transform: scale(1.05); }  /* dub */
-        46%  { opacity: 0.38; transform: scale(1);    }
-        100% { opacity: 0.38; transform: scale(1);    }  /* rest */
+    /*
+      wheel-roll-in:
+      - Starts 50vw to the left, invisible, not rotated
+      - Fades in quickly as it enters the viewport
+      - Rolls (translates + rotates clockwise) to center
+      - cubic-bezier(0.22, 0.61, 0.36, 1) = natural deceleration / ease-out-back-lite
+      - 720deg = 2 full rotations over ~50vw travel distance
+    */
+    @keyframes wheel-roll-in {
+        0% {
+            opacity: 0;
+            transform: translateX(-50vw) rotate(0deg);
+        }
+        12% {
+            opacity: 0.42;
+        }
+        100% {
+            opacity: 0.42;
+            transform: translateX(0) rotate(720deg);
+        }
     }
 
     @keyframes content-in {
-        from { opacity: 0; transform: translateY(6px); }
+        from { opacity: 0; transform: translateY(5px); }
         to   { opacity: 1; transform: translateY(0);   }
     }
 

--- a/frontend/src/components/home/SplashScreen.astro
+++ b/frontend/src/components/home/SplashScreen.astro
@@ -4,7 +4,8 @@
 ---
 
 <div class="splash" id="acc-splash" aria-hidden="true">
-    <div class="splash-bg-logo">
+    <!-- Logo: top, prominent, heartbeat animation -->
+    <div class="splash-logo">
         <img
             src="/images/transparent_red_logo.png"
             alt=""
@@ -12,10 +13,14 @@
             draggable="false"
         />
     </div>
+
+    <!-- Text: below logo, no overlap -->
     <div class="splash-content">
         <h1 class="splash-name">ACC ClubHub</h1>
         <p class="splash-tagline">Ride free, ride together.</p>
     </div>
+
+    <!-- Progress bar -->
     <div class="splash-progress">
         <div class="splash-progress-bar"></div>
     </div>
@@ -28,58 +33,58 @@
         z-index: 9999;
         background: var(--color-bg-canvas);
         display: flex;
+        flex-direction: column;
         align-items: center;
         justify-content: center;
+        gap: 1.5rem;
         pointer-events: none;
-        /* JS controls fade-out; start fully visible */
         opacity: 1;
         transition: opacity 0.5s ease;
     }
 
-    .splash-bg-logo {
-        position: absolute;
-        inset: 0;
+    /* Logo — in flow, above text */
+    .splash-logo {
         display: flex;
         align-items: center;
         justify-content: center;
-        overflow: hidden;
     }
 
-    .splash-bg-logo img {
-        width: min(65vw, 560px);
+    .splash-logo img {
+        width: min(42vw, 320px);
         height: auto;
         opacity: 0;
-        transform: scale(0.92);
-        animation: logo-breathe 2s ease forwards;
         user-select: none;
+        animation: logo-in 0.5s ease forwards, logo-heartbeat 1.4s 0.5s ease forwards;
     }
 
+    /* Text — below logo */
     .splash-content {
-        position: relative;
-        z-index: 1;
         text-align: center;
-        animation: content-in 0.4s ease forwards;
     }
 
     .splash-name {
         font-family: var(--font-heading);
-        font-size: clamp(2.5rem, 7vw, 4.5rem);
+        font-size: clamp(1.8rem, 5vw, 3rem);
         font-weight: 700;
         color: var(--color-accent);
-        letter-spacing: -0.03em;
+        letter-spacing: -0.02em;
         line-height: 1;
         margin: 0;
+        opacity: 0;
+        animation: content-in 0.4s 0.3s ease forwards;
     }
 
     .splash-tagline {
         font-family: var(--font-body);
-        font-size: clamp(0.9rem, 2vw, 1.1rem);
+        font-size: clamp(0.85rem, 1.8vw, 1rem);
         color: var(--color-text-secondary);
-        margin-top: 0.6rem;
+        margin-top: 0.4rem;
         letter-spacing: 0.02em;
-        animation: content-in 0.4s 0.15s ease both;
+        opacity: 0;
+        animation: content-in 0.4s 0.5s ease forwards;
     }
 
+    /* Progress bar — pinned to bottom */
     .splash-progress {
         position: absolute;
         bottom: 0;
@@ -97,15 +102,23 @@
         animation: progress-fill 1.7s linear forwards;
     }
 
-    @keyframes logo-breathe {
-        0%   { opacity: 0;    transform: scale(0.92); }
-        25%  { opacity: 0.1;  transform: scale(1.0);  }
-        70%  { opacity: 0.12; transform: scale(1.02); }
-        100% { opacity: 0.08; transform: scale(1.05); }
+    /* Logo: fade in → heartbeat (lub-dub double-pulse) */
+    @keyframes logo-in {
+        from { opacity: 0; transform: scale(0.9); }
+        to   { opacity: 0.38; transform: scale(1); }
+    }
+
+    @keyframes logo-heartbeat {
+        0%   { opacity: 0.38; transform: scale(1);    }
+        12%  { opacity: 0.45; transform: scale(1.07); }  /* lub */
+        22%  { opacity: 0.38; transform: scale(0.99); }
+        34%  { opacity: 0.44; transform: scale(1.05); }  /* dub */
+        46%  { opacity: 0.38; transform: scale(1);    }
+        100% { opacity: 0.38; transform: scale(1);    }  /* rest */
     }
 
     @keyframes content-in {
-        from { opacity: 0; transform: translateY(8px); }
+        from { opacity: 0; transform: translateY(6px); }
         to   { opacity: 1; transform: translateY(0);   }
     }
 

--- a/frontend/src/pages/[lang]/index.astro
+++ b/frontend/src/pages/[lang]/index.astro
@@ -7,6 +7,7 @@ import { locales, defaultLocale, t, type Locale } from "../../lib/i18n";
 import { splitEvents } from "../../lib/events/eventHelpers";
 import NextRideBanner from "../../components/home/NextRideBanner.astro";
 import PillarSection from "../../components/home/PillarSection.astro";
+import SplashScreen from "../../components/home/SplashScreen.astro";
 
 export function getStaticPaths() {
     return locales.map((lang) => ({ params: { lang } }));
@@ -72,6 +73,8 @@ const routeItems = allRoutes
     headerTransparent={true}
     heroImagePreload="/images/uploads/rr120_2026_group.jpg"
 >
+    <SplashScreen />
+
     <!-- Hero: full-width, breaks out of main's max-width -->
     <section slot="hero" class="homepage-hero">
         <div class="hero-overlay"></div>


### PR DESCRIPTION
## Summary

- Add ACC logo splash screen intro animation on homepage (wheel rolls in from left, decelerates to center, text fades in after wheel settles)
- Shows once per browser session via `sessionStorage` — not shown on repeat visits
- Fix section spacing: reduce vertical padding from 4rem → 2rem for tighter magazine feel
- Remove harsh alternating white/gray section backgrounds, replace with consistent canvas + subtle 1px border-top dividers

## Components

- **New**: `frontend/src/components/home/SplashScreen.astro`
- **Modified**: `frontend/src/components/home/PillarSection.astro`
- **Modified**: `frontend/src/pages/[lang]/index.astro`

## Test plan

- [ ] First visit to `/zh`, `/en`, `/de` → 2s branded splash plays (logo rolls in, text fades in, progress bar fills)
- [ ] Navigate away and back → splash skipped
- [ ] Refresh → splash skipped
- [ ] `sessionStorage.clear()` in devtools + refresh → splash replays
- [ ] Toggle dark mode → splash background matches dark canvas, borders subtle
- [ ] Mobile (375px) → wheel scales down properly, no horizontal overflow
- [ ] Section spacing feels tighter and more editorial, no jarring gray/white dividers
- [ ] `npm run build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a homepage splash screen animation displayed on initial page load, featuring a rotating logo wheel, fade-in text, and animated progress bar. The splash screen appears once per browser session.

* **Documentation**
  * Added planning documentation for upcoming homepage redesign improvements, including layout restructuring and new component architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->