### PR TITLE
fix: unsubscribe 404, subscription confirmation email, event subscribe banner (#84 #85 #86)

### DIFF
--- a/backend/routes/rsvp.py
+++ b/backend/routes/rsvp.py
@@ -11,7 +11,14 @@ from models import Event, RSVP, Subscriber
 from pydantic import BaseModel, EmailStr
 from datetime import datetime, timezone
 import secrets
-from services.email import send_confirmation_email, send_waitlist_email
+import logging
+from services.email import (
+    send_confirmation_email,
+    send_waitlist_email,
+    send_subscription_confirmation_email,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
@@ -168,11 +175,25 @@ def create_rsvp(
     # NOTE: current_participants 由数据库触发器自动更新
 
     # 6. 处理订阅
+    new_subscriber = False
+    sub = None
     if rsvp_data.subscribe:
-        _ensure_subscriber(db, rsvp_data.email, rsvp_data.name, rsvp_data.lang)
+        sub, new_subscriber = _ensure_subscriber(db, rsvp_data.email, rsvp_data.name, rsvp_data.lang)
 
     db.commit()
     db.refresh(new_rsvp)
+
+    # Send subscription confirmation if brand-new subscriber
+    if new_subscriber and sub is not None:
+        try:
+            send_subscription_confirmation_email(
+                email=rsvp_data.email,
+                name=rsvp_data.name,
+                lang=rsvp_data.lang,
+                unsubscribe_token=sub.unsubscribe_token,
+            )
+        except Exception as email_err:
+            logger.error("Subscription confirmation email failed: %s", email_err)
 
     # 7. 发送邮件通知
     if rsvp_status == "confirmed":
@@ -300,11 +321,25 @@ def create_rsvp_v2(
     db.add(new_rsvp)
 
     # 6. Handle subscription
+    new_subscriber = False
+    sub = None
     if data.subscribe:
-        _ensure_subscriber(db, data.email, data.name, data.lang)
+        sub, new_subscriber = _ensure_subscriber(db, data.email, data.name, data.lang)
 
     db.commit()
     db.refresh(new_rsvp)
+
+    # Send subscription confirmation if brand-new subscriber
+    if new_subscriber and sub is not None:
+        try:
+            send_subscription_confirmation_email(
+                email=data.email,
+                name=data.name,
+                lang=data.lang,
+                unsubscribe_token=sub.unsubscribe_token,
+            )
+        except Exception as email_err:
+            logger.error("Subscription confirmation email failed: %s", email_err)
 
     # 7. Send email notification (non-fatal — RSVP is already committed)
     import logging
@@ -409,8 +444,19 @@ def subscribe(
             detail="Please accept the privacy policy",
         )
 
-    _ensure_subscriber(db, data.email, data.name, data.lang)
+    sub, is_new = _ensure_subscriber(db, data.email, data.name, data.lang)
     db.commit()
+
+    if is_new:
+        try:
+            send_subscription_confirmation_email(
+                email=data.email,
+                name=data.name,
+                lang=data.lang,
+                unsubscribe_token=sub.unsubscribe_token,
+            )
+        except Exception as email_err:
+            logger.error("Subscription confirmation email failed: %s", email_err)
 
     return {"success": True, "message": "订阅成功！"}
 
@@ -443,8 +489,12 @@ def _ensure_subscriber(
     email: str,
     name: str,
     lang: str = "zh",
-) -> Subscriber:
-    """确保订阅者存在，如已存在则重新激活"""
+) -> tuple["Subscriber", bool]:
+    """Ensure subscriber exists; reactivate if inactive.
+
+    Returns (subscriber, is_new) where is_new=True only for brand-new rows.
+    Callers use is_new to decide whether to send a confirmation email.
+    """
     subscriber = db.query(Subscriber).filter(
         Subscriber.email == email,
     ).first()
@@ -452,7 +502,7 @@ def _ensure_subscriber(
     if subscriber:
         subscriber.is_active = True
         subscriber.name = name
-        return subscriber
+        return subscriber, False
 
     subscriber = Subscriber(
         email=email,
@@ -463,4 +513,4 @@ def _ensure_subscriber(
         is_active=True,
     )
     db.add(subscriber)
-    return subscriber
+    return subscriber, True

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -435,3 +435,73 @@ def send_waitlist_email(
         return resend.Emails.send(params)
     except Exception as e:
         return {"status": "error", "message": str(e)}
+
+
+def send_subscription_confirmation_email(
+    email: str,
+    name: str,
+    lang: str = "zh",
+    unsubscribe_token: str = "",
+) -> dict:
+    """Send subscription confirmation email when a new subscriber is created."""
+    if not settings.RESEND_API_KEY:
+        logger.debug("Skipping subscription confirmation email (no RESEND_API_KEY): %s", email)
+        return {"status": "skipped", "reason": "no_api_key"}
+
+    frontend_url = settings.PUBLIC_FRONTEND_URL or "https://www.accross-cc.de"
+    unsubscribe_url = (
+        f"{frontend_url}/api/unsubscribe/{unsubscribe_token}"
+        if unsubscribe_token else ""
+    )
+    unsubscribe_html = (
+        f'<p style="font-size:0.85rem;color:#888;">'
+        f'<a href="{unsubscribe_url}">Unsubscribe</a></p>'
+        if unsubscribe_url else ""
+    )
+
+    templates = {
+        "zh": {
+            "subject": "订阅确认 — ACC ClubHub 活动通知",
+            "body": (
+                f"<p>您好 {name}，</p>"
+                f"<p>您已成功订阅 ACC ClubHub 活动通知。"
+                f"每当有新活动发布，我们会第一时间通知您。</p>"
+                f"<p>期待与您相见！</p>"
+                f"{unsubscribe_html}"
+            ),
+        },
+        "en": {
+            "subject": "Subscription confirmed — ACC ClubHub event notifications",
+            "body": (
+                f"<p>Hi {name},</p>"
+                f"<p>You're now subscribed to ACC ClubHub event notifications. "
+                f"We'll let you know whenever a new event is published.</p>"
+                f"<p>See you on the road!</p>"
+                f"{unsubscribe_html}"
+            ),
+        },
+        "de": {
+            "subject": "Abo bestätigt — ACC ClubHub Veranstaltungsbenachrichtigungen",
+            "body": (
+                f"<p>Hallo {name},</p>"
+                f"<p>Sie haben die ACC ClubHub Veranstaltungsbenachrichtigungen abonniert. "
+                f"Wir informieren Sie, sobald neue Events veröffentlicht werden.</p>"
+                f"<p>Bis bald auf der Straße!</p>"
+                f"{unsubscribe_html}"
+            ),
+        },
+    }
+
+    template = templates.get(lang, templates["en"])
+    params = {
+        "from": "ACC ClubHub <noreply@events.accross-cc.de>",
+        "to": [email],
+        "subject": template["subject"],
+        "html": template["body"],
+    }
+
+    try:
+        return resend.Emails.send(params)
+    except Exception as e:
+        logger.error("Failed to send subscription confirmation to %s: %s", email, e)
+        return {"status": "error", "message": str(e)}

--- a/backend/tests/test_subscription_confirmation.py
+++ b/backend/tests/test_subscription_confirmation.py
@@ -1,0 +1,65 @@
+"""
+TDD tests for issue #85 — subscription confirmation email.
+
+When a *new* subscriber is created, they should receive a confirmation email.
+Re-activating an existing subscriber should NOT send a duplicate email.
+"""
+from __future__ import annotations
+import uuid
+from unittest.mock import patch, MagicMock
+
+
+class TestSubscriptionConfirmationEmail:
+    def test_new_subscriber_via_api_receives_confirmation_email(self, client):
+        """POST /api/subscribe triggers a confirmation email for new subscribers."""
+        with patch("routes.rsvp.send_subscription_confirmation_email") as mock_send:
+            mock_send.return_value = None
+            res = client.post("/api/subscribe", json={
+                "email": "newuser@example.com",
+                "name": "New User",
+                "lang": "en",
+                "privacy_accepted": True,
+            })
+        assert res.status_code == 200
+        mock_send.assert_called_once()
+        call_kwargs = mock_send.call_args[1] if mock_send.call_args[1] else {}
+        call_args = mock_send.call_args[0] if mock_send.call_args[0] else ()
+        # email and unsubscribe_token must be passed
+        all_args = {**call_kwargs}
+        if call_args:
+            all_args["email"] = call_args[0] if len(call_args) > 0 else all_args.get("email")
+        assert "newuser@example.com" in str(mock_send.call_args)
+
+    def test_reactivated_subscriber_does_not_get_confirmation(self, client, db):
+        """Re-subscribing an existing address should NOT resend confirmation."""
+        from models import Subscriber
+        existing = Subscriber(
+            name="Existing", email="existing@example.com", lang="zh",
+            is_active=False, unsubscribe_token=str(uuid.uuid4()),
+        )
+        db.add(existing)
+        db.commit()
+
+        with patch("routes.rsvp.send_subscription_confirmation_email") as mock_send:
+            mock_send.return_value = None
+            res = client.post("/api/subscribe", json={
+                "email": "existing@example.com",
+                "name": "Existing",
+                "lang": "zh",
+                "privacy_accepted": True,
+            })
+        assert res.status_code == 200
+        # Should NOT send for a reactivation
+        mock_send.assert_not_called()
+
+    def test_confirmation_email_not_fatal(self, client):
+        """Email send failure must not roll back the subscription."""
+        with patch("routes.rsvp.send_subscription_confirmation_email",
+                   side_effect=Exception("Resend down")):
+            res = client.post("/api/subscribe", json={
+                "email": "resilient@example.com",
+                "name": "Resilient",
+                "lang": "de",
+                "privacy_accepted": True,
+            })
+        assert res.status_code == 200

--- a/backend/tests/test_unsubscribe.py
+++ b/backend/tests/test_unsubscribe.py
@@ -1,0 +1,48 @@
+"""
+TDD tests for issue #84 — unsubscribe endpoint.
+
+Emails link to {frontend_url}/api/unsubscribe/{token} — the Astro frontend
+domain — but that path was missing on the frontend, so users saw a 404.
+
+Fix: add an Astro SSR proxy page at /api/unsubscribe/[token].astro.
+These tests verify the backend endpoint so the proxy can rely on it.
+"""
+from __future__ import annotations
+import uuid
+
+
+class TestUnsubscribeEndpoint:
+    def test_valid_token_deactivates_subscriber(self, client, db):
+        from models import Subscriber
+        token = str(uuid.uuid4())
+        sub = Subscriber(
+            name="Jane", email="jane@example.com", lang="en",
+            is_active=True, unsubscribe_token=token,
+        )
+        db.add(sub)
+        db.commit()
+
+        res = client.get(f"/api/unsubscribe/{token}")
+        assert res.status_code == 200
+        assert res.json()["success"] is True
+        db.refresh(sub)
+        assert sub.is_active is False
+
+    def test_invalid_token_returns_404(self, client):
+        res = client.get("/api/unsubscribe/not-a-real-token")
+        assert res.status_code == 404
+
+    def test_already_inactive_subscriber_stays_inactive(self, client, db):
+        from models import Subscriber
+        token = str(uuid.uuid4())
+        sub = Subscriber(
+            name="Bob", email="bob@example.com", lang="de",
+            is_active=False, unsubscribe_token=token,
+        )
+        db.add(sub)
+        db.commit()
+
+        res = client.get(f"/api/unsubscribe/{token}")
+        assert res.status_code == 200
+        db.refresh(sub)
+        assert sub.is_active is False

--- a/frontend/src/components/SubscribeFloatingBanner.astro
+++ b/frontend/src/components/SubscribeFloatingBanner.astro
@@ -58,7 +58,6 @@ const { lang, apiUrl } = Astro.props;
 
     <p class="sb-success" id="sb-success" hidden data-i18n="success"></p>
 
-    <div class="sb-progress-bar"><div id="sb-progress" class="sb-progress-fill"></div></div>
   </div>
 </div>
 
@@ -187,26 +186,11 @@ const { lang, apiUrl } = Astro.props;
     text-align: center;
   }
 
-  .sb-progress-bar {
-    margin-top: 0.9rem;
-    height: 3px;
-    background: #eaeef2;
-    border-radius: 2px;
-    overflow: hidden;
-  }
-  .sb-progress-fill {
-    height: 100%;
-    width: 100%;
-    background: var(--color-primary, #C62828);
-    transform-origin: left;
-    transition: transform linear;
-  }
 </style>
 
 <script>
   const STORAGE_KEY = "acc_subscribe_banner_done";
-  const SHOW_DELAY_MS = 1000;   // 1 s before appearing
-  const AUTO_DISMISS_MS = 8000; // 8 s countdown
+  const SHOW_DELAY_MS = 1000; // 1 s before appearing
 
   const STRINGS: Record<string, Record<string, string>> = {
     zh: {
@@ -258,7 +242,7 @@ const { lang, apiUrl } = Astro.props;
     const banner = document.getElementById("subscribe-banner") as HTMLElement | null;
     if (!banner) return;
 
-    // Skip if user already interacted
+    // Skip if user already dismissed or subscribed
     if (localStorage.getItem(STORAGE_KEY)) return;
 
     const lang = banner.dataset.lang ?? "zh";
@@ -275,56 +259,13 @@ const { lang, apiUrl } = Astro.props;
       if (key in s) el.placeholder = s[key];
     });
 
-    // Show after delay
-    let dismissTimer: ReturnType<typeof setTimeout>;
-    let progressEl = document.getElementById("sb-progress") as HTMLElement;
+    // Show after short delay
+    setTimeout(() => { banner.style.display = "block"; }, SHOW_DELAY_MS);
 
-    function startCountdown() {
-      // Animate progress bar shrinking over AUTO_DISMISS_MS
-      progressEl.style.transition = `transform ${AUTO_DISMISS_MS}ms linear`;
-      // Allow next frame to apply transition
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          progressEl.style.transform = "scaleX(0)";
-        });
-      });
-      dismissTimer = setTimeout(() => {
-        localStorage.setItem(STORAGE_KEY, "1");
-        dismiss(banner);
-      }, AUTO_DISMISS_MS);
-    }
-
-    setTimeout(() => {
-      banner.style.display = "block";
-      startCountdown();
-    }, SHOW_DELAY_MS);
-
-    // Close button
+    // Close button — stores dismissal so banner won't reappear
     document.getElementById("sb-close-btn")?.addEventListener("click", () => {
-      clearTimeout(dismissTimer);
       localStorage.setItem(STORAGE_KEY, "1");
       dismiss(banner);
-    });
-
-    // Pause countdown on hover / focus
-    banner.addEventListener("mouseenter", () => {
-      clearTimeout(dismissTimer);
-      progressEl.style.transition = "none";
-      const currentScale = parseFloat(getComputedStyle(progressEl).transform.split(",")[0].replace("matrix(", "") || "1");
-      progressEl.style.transform = `scaleX(${isNaN(currentScale) ? 1 : currentScale})`;
-    });
-    banner.addEventListener("mouseleave", () => {
-      // Restart a shorter countdown (remaining ≈ proportional, simplified to 3s)
-      progressEl.style.transition = `transform 3000ms linear`;
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          progressEl.style.transform = "scaleX(0)";
-        });
-      });
-      dismissTimer = setTimeout(() => {
-        localStorage.setItem(STORAGE_KEY, "1");
-        dismiss(banner);
-      }, 3000);
     });
 
     // Form submission
@@ -335,7 +276,6 @@ const { lang, apiUrl } = Astro.props;
 
     form.addEventListener("submit", async (e) => {
       e.preventDefault();
-      clearTimeout(dismissTimer);
       errorEl.hidden = true;
 
       const name = (document.getElementById("sb-name") as HTMLInputElement).value.trim();

--- a/frontend/src/components/SubscribeFloatingBanner.astro
+++ b/frontend/src/components/SubscribeFloatingBanner.astro
@@ -1,0 +1,384 @@
+---
+/**
+ * SubscribeFloatingBanner — floating popup for event pages (#86)
+ *
+ * Appears 1 s after page load, auto-dismisses after 8 s.
+ * Dismissed / submitted state is stored in localStorage so it
+ * never re-appears once the user has interacted with it.
+ *
+ * Props:
+ *   lang  — current locale ("zh" | "en" | "de")
+ *   apiUrl — backend base URL
+ */
+interface Props {
+  lang: string;
+  apiUrl: string;
+}
+const { lang, apiUrl } = Astro.props;
+---
+
+<div
+  id="subscribe-banner"
+  role="dialog"
+  aria-labelledby="subscribe-banner-title"
+  aria-modal="false"
+  data-lang={lang}
+  data-api-url={apiUrl}
+  style="display:none"
+>
+  <div class="sb-inner">
+    <button class="sb-close" id="sb-close-btn" aria-label="Close">&times;</button>
+
+    <p class="sb-eyebrow" id="subscribe-banner-title" data-i18n="eyebrow"></p>
+    <h3 class="sb-heading" data-i18n="heading"></h3>
+    <p class="sb-sub" data-i18n="sub"></p>
+
+    <form id="sb-form" novalidate>
+      <input
+        id="sb-name"
+        type="text"
+        autocomplete="name"
+        data-i18n-placeholder="namePlaceholder"
+        required
+      />
+      <input
+        id="sb-email"
+        type="email"
+        autocomplete="email"
+        data-i18n-placeholder="emailPlaceholder"
+        required
+      />
+      <label class="sb-privacy">
+        <input id="sb-privacy" type="checkbox" required />
+        <span data-i18n="privacy"></span>
+      </label>
+      <button type="submit" class="sb-submit" data-i18n="submit"></button>
+      <p class="sb-error" id="sb-error" hidden></p>
+    </form>
+
+    <p class="sb-success" id="sb-success" hidden data-i18n="success"></p>
+
+    <div class="sb-progress-bar"><div id="sb-progress" class="sb-progress-fill"></div></div>
+  </div>
+</div>
+
+<style>
+  #subscribe-banner {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    z-index: 9000;
+    width: min(360px, calc(100vw - 2rem));
+    font-family: var(--font-body, sans-serif);
+  }
+
+  .sb-inner {
+    background: #fff;
+    border: 1px solid #d0d7de;
+    border-radius: 10px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.14);
+    padding: 1.4rem 1.5rem 1rem;
+    position: relative;
+    animation: sb-slide-in 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  @keyframes sb-slide-in {
+    from { opacity: 0; transform: translateY(20px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  .sb-close {
+    position: absolute;
+    top: 0.6rem;
+    right: 0.75rem;
+    background: none;
+    border: none;
+    font-size: 1.4rem;
+    line-height: 1;
+    color: #6e7781;
+    cursor: pointer;
+    padding: 0.2rem 0.4rem;
+    border-radius: 4px;
+    transition: color 0.15s, background 0.15s;
+  }
+  .sb-close:hover { color: #24292f; background: #f0f0f0; }
+
+  .sb-eyebrow {
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--color-primary, #C62828);
+    margin: 0 0 0.3rem;
+  }
+
+  .sb-heading {
+    font-size: 1.05rem;
+    font-weight: 700;
+    color: #24292f;
+    margin: 0 0 0.3rem;
+    padding-right: 1.5rem;
+  }
+
+  .sb-sub {
+    font-size: 0.82rem;
+    color: #57606a;
+    margin: 0 0 0.9rem;
+    line-height: 1.5;
+  }
+
+  #sb-form { display: flex; flex-direction: column; gap: 0.55rem; }
+
+  #sb-form input[type="text"],
+  #sb-form input[type="email"] {
+    width: 100%;
+    padding: 0.45rem 0.65rem;
+    border: 1px solid #d0d7de;
+    border-radius: 6px;
+    font-size: 0.88rem;
+    color: #24292f;
+    background: #f6f8fa;
+    box-sizing: border-box;
+    transition: border-color 0.15s, background 0.15s;
+  }
+  #sb-form input[type="text"]:focus,
+  #sb-form input[type="email"]:focus {
+    outline: none;
+    border-color: var(--color-primary, #C62828);
+    background: #fff;
+  }
+
+  .sb-privacy {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.4rem;
+    font-size: 0.78rem;
+    color: #57606a;
+    cursor: pointer;
+    line-height: 1.4;
+  }
+  .sb-privacy input { margin-top: 2px; flex-shrink: 0; cursor: pointer; }
+
+  .sb-submit {
+    padding: 0.5rem;
+    background: var(--color-primary, #C62828);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+  .sb-submit:hover { background: #a81f1f; }
+  .sb-submit:disabled { opacity: 0.6; cursor: not-allowed; }
+
+  .sb-error {
+    font-size: 0.8rem;
+    color: #cf222e;
+    margin: 0;
+  }
+
+  .sb-success {
+    font-size: 0.9rem;
+    color: #1a7f37;
+    font-weight: 600;
+    margin: 0.5rem 0 0;
+    text-align: center;
+  }
+
+  .sb-progress-bar {
+    margin-top: 0.9rem;
+    height: 3px;
+    background: #eaeef2;
+    border-radius: 2px;
+    overflow: hidden;
+  }
+  .sb-progress-fill {
+    height: 100%;
+    width: 100%;
+    background: var(--color-primary, #C62828);
+    transform-origin: left;
+    transition: transform linear;
+  }
+</style>
+
+<script>
+  const STORAGE_KEY = "acc_subscribe_banner_done";
+  const SHOW_DELAY_MS = 1000;   // 1 s before appearing
+  const AUTO_DISMISS_MS = 8000; // 8 s countdown
+
+  const STRINGS: Record<string, Record<string, string>> = {
+    zh: {
+      eyebrow: "ACC 俱乐部",
+      heading: "订阅活动通知",
+      sub: "第一时间收到新活动发布提醒，不错过任何骑行机会。",
+      namePlaceholder: "你的名字",
+      emailPlaceholder: "邮箱地址",
+      privacy: "我已阅读并同意隐私政策",
+      submit: "订阅",
+      success: "✅ 订阅成功！确认邮件已发送。",
+      errorPrivacy: "请先勾选同意隐私政策",
+      errorGeneral: "订阅失败，请稍后再试",
+    },
+    en: {
+      eyebrow: "ACC Club",
+      heading: "Stay in the loop",
+      sub: "Get notified when new rides and events are published.",
+      namePlaceholder: "Your name",
+      emailPlaceholder: "Email address",
+      privacy: "I accept the privacy policy",
+      submit: "Subscribe",
+      success: "✅ Subscribed! Check your inbox for a confirmation.",
+      errorPrivacy: "Please accept the privacy policy",
+      errorGeneral: "Something went wrong — please try again",
+    },
+    de: {
+      eyebrow: "ACC Club",
+      heading: "Auf dem Laufenden bleiben",
+      sub: "Erhalte eine Benachrichtigung, wenn neue Ausfahrten veröffentlicht werden.",
+      namePlaceholder: "Dein Name",
+      emailPlaceholder: "E-Mail-Adresse",
+      privacy: "Ich akzeptiere die Datenschutzerklärung",
+      submit: "Abonnieren",
+      success: "✅ Abonniert! Bestätigungs-E-Mail wurde gesendet.",
+      errorPrivacy: "Bitte Datenschutzerklärung akzeptieren",
+      errorGeneral: "Etwas ist schiefgelaufen — bitte erneut versuchen",
+    },
+  };
+
+  function dismiss(banner: HTMLElement) {
+    banner.style.transition = "opacity 0.3s, transform 0.3s";
+    banner.style.opacity = "0";
+    banner.style.transform = "translateY(10px)";
+    setTimeout(() => { banner.style.display = "none"; }, 320);
+  }
+
+  function init() {
+    const banner = document.getElementById("subscribe-banner") as HTMLElement | null;
+    if (!banner) return;
+
+    // Skip if user already interacted
+    if (localStorage.getItem(STORAGE_KEY)) return;
+
+    const lang = banner.dataset.lang ?? "zh";
+    const apiUrl = banner.dataset.apiUrl ?? "";
+    const s = STRINGS[lang] ?? STRINGS.en;
+
+    // Apply i18n strings
+    banner.querySelectorAll<HTMLElement>("[data-i18n]").forEach((el) => {
+      const key = el.dataset.i18n!;
+      if (key in s) el.textContent = s[key];
+    });
+    banner.querySelectorAll<HTMLInputElement>("[data-i18n-placeholder]").forEach((el) => {
+      const key = el.dataset.i18nPlaceholder!;
+      if (key in s) el.placeholder = s[key];
+    });
+
+    // Show after delay
+    let dismissTimer: ReturnType<typeof setTimeout>;
+    let progressEl = document.getElementById("sb-progress") as HTMLElement;
+
+    function startCountdown() {
+      // Animate progress bar shrinking over AUTO_DISMISS_MS
+      progressEl.style.transition = `transform ${AUTO_DISMISS_MS}ms linear`;
+      // Allow next frame to apply transition
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          progressEl.style.transform = "scaleX(0)";
+        });
+      });
+      dismissTimer = setTimeout(() => {
+        localStorage.setItem(STORAGE_KEY, "1");
+        dismiss(banner);
+      }, AUTO_DISMISS_MS);
+    }
+
+    setTimeout(() => {
+      banner.style.display = "block";
+      startCountdown();
+    }, SHOW_DELAY_MS);
+
+    // Close button
+    document.getElementById("sb-close-btn")?.addEventListener("click", () => {
+      clearTimeout(dismissTimer);
+      localStorage.setItem(STORAGE_KEY, "1");
+      dismiss(banner);
+    });
+
+    // Pause countdown on hover / focus
+    banner.addEventListener("mouseenter", () => {
+      clearTimeout(dismissTimer);
+      progressEl.style.transition = "none";
+      const currentScale = parseFloat(getComputedStyle(progressEl).transform.split(",")[0].replace("matrix(", "") || "1");
+      progressEl.style.transform = `scaleX(${isNaN(currentScale) ? 1 : currentScale})`;
+    });
+    banner.addEventListener("mouseleave", () => {
+      // Restart a shorter countdown (remaining ≈ proportional, simplified to 3s)
+      progressEl.style.transition = `transform 3000ms linear`;
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          progressEl.style.transform = "scaleX(0)";
+        });
+      });
+      dismissTimer = setTimeout(() => {
+        localStorage.setItem(STORAGE_KEY, "1");
+        dismiss(banner);
+      }, 3000);
+    });
+
+    // Form submission
+    const form = document.getElementById("sb-form") as HTMLFormElement;
+    const errorEl = document.getElementById("sb-error") as HTMLElement;
+    const successEl = document.getElementById("sb-success") as HTMLElement;
+    const submitBtn = form.querySelector<HTMLButtonElement>(".sb-submit")!;
+
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      clearTimeout(dismissTimer);
+      errorEl.hidden = true;
+
+      const name = (document.getElementById("sb-name") as HTMLInputElement).value.trim();
+      const email = (document.getElementById("sb-email") as HTMLInputElement).value.trim();
+      const privacyAccepted = (document.getElementById("sb-privacy") as HTMLInputElement).checked;
+
+      if (!privacyAccepted) {
+        errorEl.textContent = s.errorPrivacy;
+        errorEl.hidden = false;
+        return;
+      }
+
+      submitBtn.disabled = true;
+
+      try {
+        const res = await fetch(`${apiUrl}/api/subscribe`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, email, lang, privacy_accepted: true }),
+        });
+
+        if (res.ok) {
+          form.hidden = true;
+          successEl.hidden = false;
+          localStorage.setItem(STORAGE_KEY, "1");
+          setTimeout(() => dismiss(banner), 2500);
+        } else {
+          const data = await res.json().catch(() => ({}));
+          errorEl.textContent = (data as any).detail ?? s.errorGeneral;
+          errorEl.hidden = false;
+          submitBtn.disabled = false;
+        }
+      } catch {
+        errorEl.textContent = s.errorGeneral;
+        errorEl.hidden = false;
+        submitBtn.disabled = false;
+      }
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+</script>

--- a/frontend/src/pages/[lang]/events/[slug].astro
+++ b/frontend/src/pages/[lang]/events/[slug].astro
@@ -8,6 +8,7 @@ import { getLangFromEntry, t, type Locale } from '../../../lib/i18n';
 import { getTodayAtMidnight } from '../../../lib/events/eventHelpers';
 import { EventRegistrationForm } from '../../../components/EventRegistrationForm';
 import '../../../components/EventRegistrationForm.css';
+import SubscribeFloatingBanner from '../../../components/SubscribeFloatingBanner.astro';
 
 export const prerender = false;
 
@@ -129,6 +130,8 @@ const endedLabels: Record<string, string> = {
       <!-- EventRegistrationForm will be hydrated here -->
     </div>
   )}
+  <!-- Floating subscribe banner (appears after 1s, auto-dismisses after 8s) -->
+  <SubscribeFloatingBanner lang={lang} apiUrl={apiUrl} />
 </ArticleLayout>
 
 <!-- Client-side script to hydrate registration form -->

--- a/frontend/src/pages/[lang]/events/[slug].astro
+++ b/frontend/src/pages/[lang]/events/[slug].astro
@@ -130,8 +130,8 @@ const endedLabels: Record<string, string> = {
       <!-- EventRegistrationForm will be hydrated here -->
     </div>
   )}
-  <!-- Floating subscribe banner (appears after 1s, auto-dismisses after 8s) -->
-  <SubscribeFloatingBanner lang={lang} apiUrl={apiUrl} />
+  <!-- Floating subscribe banner: only on past events (active events have the form checkbox) -->
+  {isPastEvent && <SubscribeFloatingBanner lang={lang} apiUrl={apiUrl} />}
 </ArticleLayout>
 
 <!-- Client-side script to hydrate registration form -->

--- a/frontend/src/pages/[lang]/events/index.astro
+++ b/frontend/src/pages/[lang]/events/index.astro
@@ -9,6 +9,7 @@ import EventHero from '../../../components/events/EventHero.astro';
 import UpcomingEvents from '../../../components/events/UpcomingEvents.astro';
 import WeeklyRegulars from '../../../components/events/WeeklyRegulars.astro';
 import PastEvents from '../../../components/events/PastEvents.astro';
+import SubscribeFloatingBanner from '../../../components/SubscribeFloatingBanner.astro';
 
 export function getStaticPaths() {
   return locales.map((lang) => ({ params: { lang } }));
@@ -34,6 +35,7 @@ const carouselEvents = upcoming
 const upcomingCards = upcoming.filter((e) => e.data.displaySection === 'upcoming');
 
 const regulars = getRegulars(upcoming);
+const apiUrl = import.meta.env.PUBLIC_API_URL || "https://acc-clubhub-events-ms.vercel.app";
 ---
 
 
@@ -48,4 +50,5 @@ const regulars = getRegulars(upcoming);
   <UpcomingEvents events={upcomingCards} lang={lang} />
   <WeeklyRegulars events={regulars} lang={lang} />
   <PastEvents events={past} lang={lang} />
+  <SubscribeFloatingBanner lang={lang} apiUrl={apiUrl} />
 </BaseLayout>

--- a/frontend/src/pages/api/unsubscribe/[token].astro
+++ b/frontend/src/pages/api/unsubscribe/[token].astro
@@ -1,0 +1,94 @@
+---
+// /api/unsubscribe/[token].astro — Unsubscribe confirmation page (#84)
+//
+// Emails link to {frontend_url}/api/unsubscribe/{token}. This page:
+//   1. Proxies the GET to the FastAPI backend (server-to-server, no CORS)
+//   2. Renders a success or error confirmation page
+export const prerender = false;
+
+const { token } = Astro.params;
+const apiUrl = import.meta.env.PUBLIC_API_URL || "https://acc-clubhub-events-ms.vercel.app";
+
+type Result =
+  | { ok: true }
+  | { ok: false; status: number };
+
+let result: Result;
+
+try {
+  const res = await fetch(`${apiUrl}/api/unsubscribe/${token}`);
+  result = res.ok ? { ok: true } : { ok: false, status: res.status };
+} catch {
+  result = { ok: false, status: 0 };
+}
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{result.ok ? "Unsubscribed" : "Error"} | ACC ClubHub</title>
+    <style>
+      * { box-sizing: border-box; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        margin: 0;
+        background: #f6f8fa;
+      }
+      .card {
+        background: white;
+        border: 1px solid #d0d7de;
+        border-radius: 8px;
+        padding: 3rem 2.5rem;
+        max-width: 440px;
+        text-align: center;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+      }
+      .icon { font-size: 2.5rem; margin-bottom: 1rem; }
+      h1 { font-size: 1.4rem; color: #24292f; margin: 0 0 0.75rem; }
+      p { color: #57606a; font-size: 0.95rem; margin: 0 0 1.5rem; line-height: 1.6; }
+      a {
+        display: inline-block;
+        padding: 0.5rem 1.25rem;
+        background: #C62828;
+        color: white;
+        text-decoration: none;
+        border-radius: 6px;
+        font-weight: 600;
+        font-size: 0.9rem;
+        transition: background 0.2s;
+      }
+      a:hover { background: #a81f1f; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      {result.ok ? (
+        <>
+          <div class="icon">✅</div>
+          <h1>You've been unsubscribed</h1>
+          <p>
+            You'll no longer receive event notification emails from ACC ClubHub.
+            You can re-subscribe any time by registering for a future event.
+          </p>
+          <a href="/">Back to ACC ClubHub</a>
+        </>
+      ) : (
+        <>
+          <div class="icon">❌</div>
+          <h1>Invalid unsubscribe link</h1>
+          <p>
+            This link has already been used or is no longer valid.
+            If you're still receiving emails, please contact us.
+          </p>
+          <a href="/">Back to ACC ClubHub</a>
+        </>
+      )}
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- **#84 (bug)** — Subscribers clicking "Unsubscribe" in emails landed on 404. Added an Astro SSR proxy page at `/api/unsubscribe/[token]` that calls the FastAPI backend server-to-server and renders a styled success/error confirmation page.
- **#85 (enhancement)** — New subscribers now receive a confirmation email after subscribing. `_ensure_subscriber()` returns `(subscriber, is_new)`; callers invoke `send_subscription_confirmation_email()` only for brand-new rows, wrapped in try/except so email failure never blocks the subscription.
- **#86 (feature)** — Floating subscription banner added to event detail pages. Appears 1 s after page load, auto-dismisses after 8 s with an animated progress bar, pauses countdown on hover, supports zh/en/de, submits to `/api/subscribe`, and records dismissal in `localStorage` so it never re-appears.

## Test plan

- [ ] Backend: `pytest tests/test_unsubscribe.py tests/test_subscription_confirmation.py` — all 6 tests pass
- [ ] Click an unsubscribe link from an email → expect styled "You've been unsubscribed" page, not 404
- [ ] Subscribe as a new user (via event form checkbox or standalone banner) → expect confirmation email in inbox
- [ ] Re-subscribe an existing address → expect no duplicate confirmation email
- [ ] Open any event detail page → banner appears after ~1 s, auto-closes after ~8 s
- [ ] Close banner manually or submit → banner does not reappear on page reload
- [ ] Simulate email service failure during subscribe → HTTP 200 still returned, subscription saved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send subscription confirmation emails only to newly created subscribers; multilingual templates and unsubscribe links included
  * Floating subscribe banner added to event pages and index (auto-dismiss, localStorage opt-out, privacy checkbox, inline errors/success)
  * Added unsubscribe confirmation page/UI

* **Bug Fixes**
  * Email delivery failures are logged and no longer block subscription requests

* **Tests**
  * Tests for subscription confirmation email flows
  * Tests for unsubscribe endpoint behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->