### PR TITLE
fix(#86): subscribe banner X button no longer blocks re-appearance

### DIFF
--- a/frontend/src/components/SubscribeFloatingBanner.astro
+++ b/frontend/src/components/SubscribeFloatingBanner.astro
@@ -262,9 +262,9 @@ const { lang, apiUrl } = Astro.props;
     // Show after short delay
     setTimeout(() => { banner.style.display = "block"; }, SHOW_DELAY_MS);
 
-    // Close button — stores dismissal so banner won't reappear
+    // Close button — only hides for this page load, does NOT persist
+    // localStorage is only set on successful subscription
     document.getElementById("sb-close-btn")?.addEventListener("click", () => {
-      localStorage.setItem(STORAGE_KEY, "1");
       dismiss(banner);
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #88. One commit missed in the original merge:

After PR #88 was merged, a bug was found: closing the subscribe banner
with X was writing to `localStorage`, which permanently blocked the banner
from appearing on any other page (including past event detail pages).

**Fix**: X button now only hides the banner for the current page load.
`localStorage` is only written on successful subscription, so the banner
can still appear independently on the events list page and past event pages
until the user actually subscribes.

## Test plan

- [ ] Clear `localStorage` key `acc_subscribe_banner_done` in DevTools
- [ ] Visit `/events` — banner appears after 1 s
- [ ] Click X — banner hides, navigate to a past event page — banner appears again ✅
- [ ] Subscribe successfully — banner never appears again on any page ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the subscribe banner's close button behavior to only persist the dismissed state when subscription is successful. The banner will now reappear on subsequent page visits unless a successful subscription has been completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->