### PR TITLE
fix(#93): event detail page i18n — serve correct language by slug+lang

### DIFF
--- a/frontend/src/lib/events/__tests__/resolveEventEntry.test.ts
+++ b/frontend/src/lib/events/__tests__/resolveEventEntry.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for event entry resolution by lang + slug.
+ * Covers issue #93: event detail page always served wrong language.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+type MockEntry = { id: string; data: { slug: string } };
+
+/** Mirrors the resolution logic in [slug].astro */
+function resolveEventEntry(
+    allEvents: MockEntry[],
+    slug: string,
+    lang: string,
+): MockEntry | undefined {
+    return (
+        allEvents.find((e) => e.data.slug === slug && e.id.startsWith(`${lang}/`)) ??
+        allEvents.find((e) => e.data.slug === slug && e.id.startsWith('zh/'))
+    );
+}
+
+const mockEvents: MockEntry[] = [
+    { id: 'zh/2026-acc-season-opening.md', data: { slug: '2026-acc-season-opening' } },
+    { id: 'en/2026-acc-season-opening.md', data: { slug: '2026-acc-season-opening' } },
+    { id: 'de/2026-acc-season-opening.md', data: { slug: '2026-acc-season-opening' } },
+    { id: 'zh/other-event.md', data: { slug: 'other-event' } },
+];
+
+describe('resolveEventEntry', () => {
+    it('returns zh entry for lang=zh', () => {
+        const entry = resolveEventEntry(mockEvents, '2026-acc-season-opening', 'zh');
+        expect(entry?.id).toBe('zh/2026-acc-season-opening.md');
+    });
+
+    it('returns en entry for lang=en', () => {
+        const entry = resolveEventEntry(mockEvents, '2026-acc-season-opening', 'en');
+        expect(entry?.id).toBe('en/2026-acc-season-opening.md');
+    });
+
+    it('returns de entry for lang=de', () => {
+        const entry = resolveEventEntry(mockEvents, '2026-acc-season-opening', 'de');
+        expect(entry?.id).toBe('de/2026-acc-season-opening.md');
+    });
+
+    it('falls back to zh when requested lang version does not exist', () => {
+        const zhOnly: MockEntry[] = [
+            { id: 'zh/2026-acc-season-opening.md', data: { slug: '2026-acc-season-opening' } },
+        ];
+        const entry = resolveEventEntry(zhOnly, '2026-acc-season-opening', 'en');
+        expect(entry?.id).toBe('zh/2026-acc-season-opening.md');
+    });
+
+    it('returns undefined for unknown slug', () => {
+        const entry = resolveEventEntry(mockEvents, 'does-not-exist', 'zh');
+        expect(entry).toBeUndefined();
+    });
+
+    it('does not confuse entries with different slugs', () => {
+        const entry = resolveEventEntry(mockEvents, 'other-event', 'en');
+        // no en version exists, falls back to zh
+        expect(entry?.id).toBe('zh/other-event.md');
+    });
+});

--- a/frontend/src/pages/[lang]/events/[slug].astro
+++ b/frontend/src/pages/[lang]/events/[slug].astro
@@ -15,7 +15,9 @@ export const prerender = false;
 // SSR: fetch content collection per request
 const { lang, slug } = Astro.params as { lang: Locale; slug: string };
 const allEvents = await getCollection('events');
-const entry = allEvents.find((e) => e.data.slug === slug);
+const entry = allEvents.find(
+  (e) => e.data.slug === slug && getLangFromEntry(e.id, 'events') === lang
+);
 
 if (!entry) {
   return Astro.redirect(`/${lang}/events`);

--- a/frontend/src/pages/[lang]/events/[slug].astro
+++ b/frontend/src/pages/[lang]/events/[slug].astro
@@ -15,9 +15,10 @@ export const prerender = false;
 // SSR: fetch content collection per request
 const { lang, slug } = Astro.params as { lang: Locale; slug: string };
 const allEvents = await getCollection('events');
-const entry = allEvents.find(
-  (e) => e.data.slug === slug && getLangFromEntry(e.id, 'events') === lang
-);
+// Fix #93: match by both slug AND lang; fall back to zh if no lang-specific version exists
+const entry =
+  allEvents.find((e) => e.data.slug === slug && e.id.startsWith(`${lang}/`)) ??
+  allEvents.find((e) => e.data.slug === slug && e.id.startsWith('zh/'));
 
 if (!entry) {
   return Astro.redirect(`/${lang}/events`);


### PR DESCRIPTION
## Summary

- Fixes #93: event detail page was always serving the first alphabetically-matched language entry (de) regardless of the URL lang param
- Replaced fragile `getLangFromEntry(e.id, 'events')` call (relied on accidental behaviour when `indexOf` returns -1) with explicit `e.id.startsWith(`${lang}/`)`
- Added zh fallback: if no lang-specific version exists, falls back to zh instead of 404
- Renamed `social-ride` label to **Coffee Ride / 咖啡骑** across all components
- Fixed `eventType` badge on event detail page — was displaying raw key (`social-ride`) instead of translated label

## Test plan

- [x] Unit tests added: `src/lib/events/__tests__/resolveEventEntry.test.ts` (6 tests — zh/en/de resolution + fallback + unknown slug)
- [ ] Visit `/zh/events/2026-acc-season-opening` → Chinese content
- [ ] Visit `/en/events/2026-acc-season-opening` → English content
- [ ] Visit `/de/events/2026-acc-season-opening` → German content
- [ ] Switch language on event detail page → content updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Events now correctly match your selected language, with automatic fallback to Chinese editions when language-specific versions are unavailable.

* **Tests**
  * Added comprehensive test coverage for language-specific event resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->