### PR TITLE
fix(email): resolve WeChat QR code relative path to absolute URL

### DIFF
--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -46,11 +46,16 @@ def send_confirmation_email(
         if event_slug and view_token
         else ""
     )
+    qr_url = (
+        wechat_qr_code if wechat_qr_code and wechat_qr_code.startswith("http")
+        else f"{frontend_url}{wechat_qr_code}"
+        if wechat_qr_code else ""
+    )
     qr_html = (
         f'<p style="margin-top:1.2em;"><strong>微信群二维码</strong><br>'
-        f'<img src="{wechat_qr_code}" alt="WeChat QR Code" '
+        f'<img src="{qr_url}" alt="WeChat QR Code" '
         f'style="width:180px;height:180px;margin-top:8px;border:1px solid #eee;border-radius:4px;" /></p>'
-        if wechat_qr_code else ""
+        if qr_url else ""
     )
 
     templates = {

--- a/backend/tests/test_confirmation_email.py
+++ b/backend/tests/test_confirmation_email.py
@@ -1,0 +1,70 @@
+"""
+Tests for send_confirmation_email — focuses on QR code URL construction.
+No actual emails are sent (RESEND_API_KEY is empty in test env).
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone
+from services.email import send_confirmation_email
+
+
+SAMPLE_DATE = datetime(2026, 4, 19, 9, 0, tzinfo=timezone.utc)
+FRONTEND_URL = "https://www.accross-cc.de"
+
+
+def _capture_email_params(**kwargs) -> dict:
+    """Call send_confirmation_email and capture the params passed to resend."""
+    captured = {}
+
+    mock_send = MagicMock(return_value={"id": "test-id"})
+
+    with patch("resend.Emails.send", mock_send), \
+         patch("services.email.settings") as mock_settings:
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.PUBLIC_FRONTEND_URL = FRONTEND_URL
+
+        send_confirmation_email(**kwargs)
+
+    assert mock_send.called, "resend.Emails.send was not called"
+    captured = mock_send.call_args[0][0]  # first positional arg = params dict
+    return captured
+
+
+def test_qr_code_relative_path_becomes_absolute():
+    """Relative /images/... path must be prefixed with the frontend URL."""
+    params = _capture_email_params(
+        user_email="test@example.com",
+        user_name="Test User",
+        event_title="ACC 2026 开春咖啡骑",
+        event_date=SAMPLE_DATE,
+        wechat_qr_code="/images/uploads/event_src/2026-season-opening/qr.png",
+    )
+    assert f'{FRONTEND_URL}/images/uploads/event_src/2026-season-opening/qr.png' in params["html"]
+
+
+def test_qr_code_absolute_url_used_as_is():
+    """Absolute https:// URL must not be double-prefixed."""
+    abs_url = "https://cdn.example.com/qr.png"
+    params = _capture_email_params(
+        user_email="test@example.com",
+        user_name="Test User",
+        event_title="ACC 2026 开春咖啡骑",
+        event_date=SAMPLE_DATE,
+        wechat_qr_code=abs_url,
+    )
+    assert f'src="{abs_url}"' in params["html"]
+    assert f'src="{FRONTEND_URL}{abs_url}"' not in params["html"]
+
+
+def test_no_qr_code_omits_img_tag():
+    """When wechat_qr_code is None, no <img> tag should appear in the email."""
+    params = _capture_email_params(
+        user_email="test@example.com",
+        user_name="Test User",
+        event_title="ACC 2026 开春咖啡骑",
+        event_date=SAMPLE_DATE,
+        wechat_qr_code=None,
+    )
+    assert "WeChat QR Code" not in params["html"]
+    assert "<img" not in params["html"]


### PR DESCRIPTION
## Summary

- Fixes WeChat QR code not showing in confirmation emails — the path `/images/...` was passed as-is into the `<img src>` tag, but email clients cannot resolve relative paths
- Now prepends `PUBLIC_FRONTEND_URL` (`https://www.accross-cc.de`) if the path is relative; absolute `https://` URLs are passed through unchanged

## Test plan

- [x] Unit tests added: `backend/tests/test_confirmation_email.py` (3 tests)
  - Relative path → prefixed with frontend URL
  - Absolute URL → used as-is, not double-prefixed
  - No QR code → no `<img>` tag in email
- [ ] Register for the season opening event and verify the WeChat QR code image loads in the confirmation email

🤖 Generated with [Claude Code](https://claude.com/claude-code)