### PR TITLE
feat(knowledge-media): editorial redesign — new card/shelf/hero components & library pages

### DIFF
--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -107,7 +107,7 @@ Events are managed entirely through the CMS — no SQL required. Or one can simp
 | `slug`                 | ✅          | URL path, e.g.`spring-classic-2026`                            |
 | `eventType`            | ✅          | `social-ride` · `training-camp` · `race` · `workshop` |
 | `displaySection`       | ✅          | Where this event appears on the events page — see table below   |
-| `coverImage`           | recommended | Path to hero image e.g.`/images/uploads/photo.jpg`             |
+| `cover`                | recommended | Path to hero image e.g.`/images/events/{slug}/cover.jpg`       |
 | `maxParticipants`      | optional    | Leave blank for unlimited                                        |
 | `registrationDeadline` | optional    | ISO date; registration form closes after this date               |
 | `author`               | optional    | Defaults to `"ACC Club"`                                       |


### PR DESCRIPTION
## Summary

- New editorial component layer: `EditorialHero`, `FeaturedShelf`, `SectionRule`
- New content cards: `ArticleCard`, `CategoryShelf`, `RouteCard` with full CSS
- Rebuilt library pages: Knowledge (gear/training), Media, Routes — all migrated to new component system
- Bulk frontmatter additions across 99 content files (knowledge, media, routes, events) in de/en/zh
- i18n expansion: ~123 new translation keys + `filterTranslations.ts`
- MAINTENANCE.md: `coverImage` → `cover` field rename, governance updates
- Plan doc added: `docs/rebuild_plan/future_add_on/knowledge_media_editorial_redesign_plan.md`
- `docs/agent-posting-spec.md` added

## Test plan

- [ ] Build passes (`npm run build` in `frontend/`)
- [ ] Knowledge gear/training index pages render correctly in all 3 languages
- [ ] Media index page renders correctly
- [ ] Routes index page renders correctly
- [ ] Filter components work on all library pages
- [ ] i18n keys resolve without missing-key warnings
- [ ] No references to deprecated `uploads/` path or `coverImage` field remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Events CMS frontmatter documentation reflecting changes to hero image field naming and file path standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->