### PR TITLE
fix(dashboard): use Markdown as source of truth for event list

### DIFF
--- a/backend/scripts/sync_events_from_markdown.py
+++ b/backend/scripts/sync_events_from_markdown.py
@@ -1,0 +1,137 @@
+"""
+Sync events from Markdown files → Database.
+
+Reads event frontmatter from frontend/src/content/events/zh/ (source of
+truth) and upserts into the DB. Events present in DB but missing from
+Markdown are marked is_public=False.
+
+Usage:
+    python backend/scripts/sync_events_from_markdown.py
+
+Requires DATABASE_URL to be set (or a .env file in backend/).
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Ensure backend package is importable
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+import yaml
+from database import get_db
+from models import Event
+
+
+EVENTS_DIR = (
+    _backend_dir.parent / "frontend" / "src" / "content" / "events" / "zh"
+)
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+
+
+def _parse_frontmatter(path: Path) -> dict | None:
+    """Extract YAML frontmatter from a Markdown file."""
+    text = path.read_text(encoding="utf-8")
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return None
+    return yaml.safe_load(m.group(1))
+
+
+def _parse_date(value: object) -> datetime:
+    """Coerce various date representations to timezone-aware datetime."""
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+    s = str(value).strip()
+    for fmt in ("%Y-%m-%d %H:%M", "%Y-%m-%d"):
+        try:
+            dt = datetime.strptime(s, fmt)
+            return dt.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    raise ValueError(f"Cannot parse date: {value!r}")
+
+
+def sync() -> None:
+    """Run the Markdown → DB sync."""
+    if not EVENTS_DIR.is_dir():
+        print(f"Events directory not found: {EVENTS_DIR}")
+        sys.exit(1)
+
+    md_slugs: set[str] = set()
+    upserted = 0
+    skipped = 0
+
+    db = next(get_db())
+
+    for md_file in sorted(EVENTS_DIR.glob("*.md")):
+        fm = _parse_frontmatter(md_file)
+        if fm is None:
+            print(f"  SKIP (no frontmatter): {md_file.name}")
+            skipped += 1
+            continue
+
+        slug = fm.get("slug") or md_file.stem
+        md_slugs.add(slug)
+
+        event_date = _parse_date(fm["date"])
+        title = fm.get("title", slug)
+        description = fm.get("description")
+        location = fm.get("location")
+        event_type = fm.get("eventType", "social-ride")
+        max_participants = fm.get("maxParticipants")
+
+        existing = db.query(Event).filter(Event.slug == slug).first()
+
+        if existing:
+            existing.title = title
+            existing.description = description
+            existing.event_date = event_date
+            existing.location = location
+            existing.event_type = event_type
+            existing.max_participants = max_participants
+            existing.is_public = True
+            print(f"  UPDATE: {slug}")
+        else:
+            new_event = Event(
+                slug=slug,
+                title=title,
+                description=description,
+                event_date=event_date,
+                location=location,
+                event_type=event_type,
+                max_participants=max_participants,
+                current_participants=0,
+                is_public=True,
+            )
+            db.add(new_event)
+            print(f"  CREATE: {slug}")
+
+        upserted += 1
+
+    # Mark DB-only events (not in Markdown) as not public
+    archived = 0
+    db_events = db.query(Event).filter(Event.is_public == True).all()
+    for event in db_events:
+        if event.slug not in md_slugs:
+            event.is_public = False
+            archived += 1
+            print(f"  ARCHIVE: {event.slug} (not in Markdown)")
+
+    db.commit()
+
+    print(
+        f"\nSync complete: {upserted} upserted, "
+        f"{archived} archived, {skipped} skipped"
+    )
+
+
+if __name__ == "__main__":
+    sync()

--- a/backend/sync.sh
+++ b/backend/sync.sh
@@ -3,4 +3,4 @@
 # Run this after creating/editing event markdown files
 
 echo "Syncing events from markdown to database..."
-python scripts/populate_events_via_api.py
+python backend/scripts/sync_events_from_markdown.py

--- a/frontend/src/content/config.ts
+++ b/frontend/src/content/config.ts
@@ -28,6 +28,7 @@ const mediaCollection = defineCollection({
 const eventsCollection = defineCollection({
     type: 'content',
     schema: z.object({
+        slug: z.string().optional(),
         title: z.string(),
         description: z.string().optional(),
         date: z.date(),

--- a/frontend/src/pages/dashboard/events/index.astro
+++ b/frontend/src/pages/dashboard/events/index.astro
@@ -1,6 +1,10 @@
 ---
 // dashboard/events/index.astro — Admin event list with stats (SSR)
+// Source of truth: Markdown content collection (same as frontend)
+// RSVP stats: enriched from backend DB API
 export const prerender = false;
+
+import { getCollection } from 'astro:content';
 
 const apiUrl = import.meta.env.PUBLIC_API_URL || "https://acc-clubhub-events-ms.vercel.app";
 
@@ -17,24 +21,56 @@ try {
   return Astro.redirect("/dashboard/login");
 }
 
-// Fetch events with stats
-let events = [];
-let fetchError = null;
+// 1. Read events from Markdown (source of truth — same as frontend)
+const allEvents = await getCollection('events');
+const zhEvents = allEvents.filter((e) => {
+  const entryLang = e.id.includes('/') ? e.id.split('/')[0] : 'zh';
+  return entryLang === 'zh';
+});
+
+// 2. Fetch RSVP stats from DB (for enrichment only)
+const dbStatsMap = new Map<string, any>();
+let statsWarning: string | null = null;
 
 try {
   const res = await fetch(`${apiUrl}/api/admin/events`, {
     headers: { "Cookie": cookie },
   });
   if (res.ok) {
-    events = await res.json();
+    const dbEvents = await res.json();
+    for (const e of dbEvents) {
+      dbStatsMap.set(e.slug, e);
+    }
   } else if (res.status === 401) {
     return Astro.redirect("/dashboard/login");
   } else {
-    fetchError = `Failed to fetch events: ${res.status}`;
+    statsWarning = `RSVP stats unavailable (API returned ${res.status})`;
   }
-} catch (e) {
-  fetchError = `Failed to fetch events: ${e.message}`;
+} catch (e: any) {
+  statsWarning = `RSVP stats unavailable: ${e.message}`;
 }
+
+// 3. Merge: Markdown events + DB RSVP stats
+const events = zhEvents.map((e) => {
+  const slug = e.data.slug ?? e.id.split('/').pop()?.replace(/\.mdx?$/, '') ?? '';
+  const stats = dbStatsMap.get(slug);
+  return {
+    slug,
+    title: e.data.title,
+    date: e.data.date instanceof Date ? e.data.date.toISOString() : String(e.data.date),
+    location: e.data.location ?? null,
+    eventType: e.data.eventType,
+    maxParticipants: e.data.maxParticipants ?? null,
+    confirmed_count: stats?.confirmed_count ?? 0,
+    waitlist_count: stats?.waitlist_count ?? 0,
+    cancelled_count: stats?.cancelled_count ?? 0,
+    spots_remaining: stats?.spots_remaining ?? null,
+    db_id: stats?.id ?? null,
+    in_db: !!stats,
+  };
+}).sort((a, b) => new Date(b.date).valueOf() - new Date(a.date).valueOf());
+
+let fetchError: string | null = null;
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return "—";
@@ -130,6 +166,8 @@ function formatDate(dateStr: string | null): string {
       }
       .action-btn:hover { background: #0860ca; text-decoration: none; }
       .error { background: #ffebe9; border: 1px solid #ff818266; padding: 1rem; border-radius: 6px; color: #cf222e; margin-bottom: 1rem; }
+      .warning { background: #fff8c5; border: 1px solid #d4a72c66; padding: 1rem; border-radius: 6px; color: #9a6700; margin-bottom: 1rem; }
+      .no-db { color: #8b949e; font-size: 0.8rem; font-style: italic; }
       .empty { text-align: center; padding: 3rem; color: #57606a; }
     </style>
   </head>
@@ -144,6 +182,7 @@ function formatDate(dateStr: string | null): string {
       </div>
 
       {fetchError && <div class="error">{fetchError}</div>}
+      {statsWarning && <div class="warning">{statsWarning}</div>}
 
       {events.length === 0 && !fetchError ? (
         <div class="empty">No events found.</div>
@@ -164,7 +203,7 @@ function formatDate(dateStr: string | null): string {
             {events.map((event: any) => (
               <tr>
                 <td class="event-title">{event.title}</td>
-                <td>{formatDate(event.event_date)}</td>
+                <td>{formatDate(event.date)}</td>
                 <td>{event.location || "—"}</td>
                 <td>
                   <span class="badge badge-confirmed">
@@ -180,9 +219,13 @@ function formatDate(dateStr: string | null): string {
                   {event.spots_remaining !== null ? event.spots_remaining : "∞"}
                 </td>
                 <td>
-                  <a href={`/dashboard/events/${event.id}`} class="action-btn">
-                    View RSVPs
-                  </a>
+                  {event.db_id ? (
+                    <a href={`/dashboard/events/${event.db_id}`} class="action-btn">
+                      View RSVPs
+                    </a>
+                  ) : (
+                    <span class="no-db" title="Event not yet synced to database">No RSVPs</span>
+                  )}
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
Dashboard now reads events from content collection (same as frontend) and enriches with RSVP stats from the DB API. This ensures both pages always show the same events.

- Dashboard events list uses getCollection('events') as primary source
- DB stats merged by slug for RSVP counts
- Events not yet in DB show 'No RSVPs' instead of broken link
- Add slug field to events Zod schema (used throughout but was missing)
- Add sync_events_from_markdown.py script to keep DB in sync
- Fix sync.sh to reference the correct sync script

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Event dashboard now displays live RSVP statistics: confirmed, waitlist, and cancelled participant counts alongside available spots remaining.
  * Events now include unique slug identifiers for improved tracking.

* **Chores**
  * Updated event synchronization process from content sources to database backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->