### PR TITLE
fix(rsvp): allow re-registration after cancellation and add restore

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -92,6 +92,7 @@ class RSVP(Base):
     email = Column(String(255), nullable=False, index=True)
     name = Column(String(100), nullable=False)
     status = Column(String(20), default="confirmed", index=True)
+    cancel_reason = Column(String(20), nullable=True)  # 'admin_cancelled' | 'user_cancelled'
     notes = Column(Text, nullable=True)
     privacy_accepted = Column(Boolean, default=False)
     view_token = Column(String(64), nullable=True, index=True)

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -113,6 +113,7 @@ def get_event_rsvps(
                 "name": r.name,
                 "email": r.email,
                 "status": r.status,
+                "cancel_reason": r.cancel_reason,
                 "notes": r.notes,
                 "created_at": r.created_at.isoformat() if r.created_at else None,
             }
@@ -166,8 +167,7 @@ def cancel_rsvp(
 
     was_confirmed = rsvp.status == "confirmed"
     rsvp.status = "cancelled"
-
-
+    rsvp.cancel_reason = "admin_cancelled"
 
     # Promote the first waitlisted RSVP when a confirmed slot opens
     promoted = None
@@ -201,6 +201,59 @@ def cancel_rsvp(
     if promoted:
         result["promoted"] = promoted.name
     return result
+
+
+# ── Admin Restore RSVP ────────────────────────────────────────
+
+class RestoreRsvpRequest(BaseModel):
+    rsvp_id: int
+
+
+@router.post("/api/admin/events/{event_id}/rsvp/restore")
+def restore_rsvp(
+    event_id: int,
+    body: RestoreRsvpRequest,
+    db: Session = Depends(get_db),
+    _admin: dict = Depends(get_current_admin),
+) -> dict:
+    """
+    Restore a cancelled RSVP back to confirmed (or waitlist if full).
+
+    Requires admin authentication.
+    """
+    event = db.query(Event).filter(Event.id == event_id).first()
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    rsvp = db.query(RSVP).filter(
+        RSVP.id == body.rsvp_id,
+        RSVP.event_id == event_id,
+    ).first()
+    if not rsvp:
+        raise HTTPException(status_code=404, detail="RSVP not found")
+
+    if rsvp.status != "cancelled":
+        return {"success": True, "message": "RSVP is not cancelled"}
+
+    # Determine restored status based on available spots
+    new_status = "confirmed"
+    if event.max_participants is not None:
+        confirmed_count = db.query(RSVP).filter(
+            RSVP.event_id == event_id,
+            RSVP.status == "confirmed",
+        ).count()
+        if confirmed_count >= event.max_participants:
+            new_status = "waitlist"
+
+    rsvp.status = new_status
+    rsvp.cancel_reason = None
+    db.commit()
+
+    return {
+        "success": True,
+        "message": f"RSVP for {rsvp.name} restored to {new_status}",
+        "new_status": new_status,
+    }
 
 
 # ── Admin CSV Export ──────────────────────────────────────────

--- a/backend/routes/rsvp.py
+++ b/backend/routes/rsvp.py
@@ -132,10 +132,14 @@ def create_rsvp(
         RSVP.email == rsvp_data.email,
     ).first()
     if existing:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="This email is already registered for this event",
-        )
+        if existing.status == "cancelled":
+            # Allow re-registration: reactivate the cancelled record
+            pass
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="This email is already registered for this event",
+            )
 
     # 4. 检查席位
     rsvp_status = "confirmed"
@@ -150,17 +154,26 @@ def create_rsvp(
                 RSVP.status == "waitlist",
             ).count() + 1
 
-    # 5. 创建 RSVP
-    new_rsvp = RSVP(
-        event_id=event_id,
-        email=rsvp_data.email,
-        name=rsvp_data.name,
-        status=rsvp_status,
-        notes=rsvp_data.notes,
-        privacy_accepted=rsvp_data.privacy_accepted,
-        view_token=secrets.token_urlsafe(32),
-    )
-    db.add(new_rsvp)
+    # 5. 创建 or reactivate RSVP
+    if existing and existing.status == "cancelled":
+        existing.status = rsvp_status
+        existing.name = rsvp_data.name
+        existing.notes = rsvp_data.notes
+        existing.privacy_accepted = rsvp_data.privacy_accepted
+        existing.view_token = secrets.token_urlsafe(32)
+        existing.cancel_reason = None
+        new_rsvp = existing
+    else:
+        new_rsvp = RSVP(
+            event_id=event_id,
+            email=rsvp_data.email,
+            name=rsvp_data.name,
+            status=rsvp_status,
+            notes=rsvp_data.notes,
+            privacy_accepted=rsvp_data.privacy_accepted,
+            view_token=secrets.token_urlsafe(32),
+        )
+        db.add(new_rsvp)
 
     # NOTE: current_participants 由数据库触发器自动更新
 
@@ -289,10 +302,14 @@ def create_rsvp_v2(
         RSVP.email == data.email,
     ).first()
     if existing:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="This email is already registered for this event",
-        )
+        if existing.status == "cancelled":
+            # Allow re-registration: reactivate the cancelled record
+            pass
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="This email is already registered for this event",
+            )
 
     # 4. Determine status (confirmed vs waitlist)
     rsvp_status = "confirmed"
@@ -308,17 +325,26 @@ def create_rsvp_v2(
                 RSVP.status == "waitlist",
             ).count() + 1
 
-    # 5. Create RSVP
-    new_rsvp = RSVP(
-        event_id=event.id,
-        email=data.email,
-        name=data.name,
-        status=rsvp_status,
-        notes=data.notes,
-        privacy_accepted=data.privacy_accepted,
-        view_token=secrets.token_urlsafe(32),
-    )
-    db.add(new_rsvp)
+    # 5. Create or reactivate RSVP
+    if existing and existing.status == "cancelled":
+        existing.status = rsvp_status
+        existing.name = data.name
+        existing.notes = data.notes
+        existing.privacy_accepted = data.privacy_accepted
+        existing.view_token = secrets.token_urlsafe(32)
+        existing.cancel_reason = None
+        new_rsvp = existing
+    else:
+        new_rsvp = RSVP(
+            event_id=event.id,
+            email=data.email,
+            name=data.name,
+            status=rsvp_status,
+            notes=data.notes,
+            privacy_accepted=data.privacy_accepted,
+            view_token=secrets.token_urlsafe(32),
+        )
+        db.add(new_rsvp)
 
     # 6. Handle subscription
     new_subscriber = False

--- a/frontend/src/pages/dashboard/events/[id].astro
+++ b/frontend/src/pages/dashboard/events/[id].astro
@@ -184,6 +184,19 @@ const statusClass: Record<string, string> = {
       }
       .cancel-btn:hover { background: #ffc9c9; }
       .cancel-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+      .restore-btn {
+        padding: 0.25rem 0.6rem;
+        background: #dafbe1;
+        color: #1a7f37 !important;
+        border: 1px solid #4ac26b66;
+        border-radius: 6px;
+        font-size: 0.75rem;
+        cursor: pointer;
+        transition: background 0.2s;
+      }
+      .restore-btn:hover { background: #a7f3d0; }
+      .restore-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+      .cancel-reason { font-size: 0.7rem; color: #8b949e; margin-left: 0.3rem; }
       .notes { max-width: 200px; font-size: 0.8rem; color: #57606a; }
       .error { background: #ffebe9; border: 1px solid #ff818266; padding: 1rem; border-radius: 6px; color: #cf222e; margin-bottom: 1rem; }
       .empty { text-align: center; padding: 3rem; color: #57606a; }
@@ -272,11 +285,23 @@ const statusClass: Record<string, string> = {
                       <span class={`badge badge-${rsvp.status}`}>
                         {rsvp.status}
                       </span>
+                      {rsvp.cancel_reason && (
+                        <span class="cancel-reason">({rsvp.cancel_reason === "admin_cancelled" ? "by admin" : "by user"})</span>
+                      )}
                     </td>
                     <td class="notes">{rsvp.notes || "—"}</td>
                     <td>{formatDate(rsvp.created_at)}</td>
                     <td>
-                      {rsvp.status !== "cancelled" && (
+                      {rsvp.status === "cancelled" ? (
+                        <button
+                          class="restore-btn"
+                          data-rsvp-id={rsvp.id}
+                          data-rsvp-name={rsvp.name}
+                          id={`restore-btn-${rsvp.id}`}
+                        >
+                          Restore
+                        </button>
+                      ) : rsvp.status !== "cancelled" && (
                         <button
                           class="cancel-btn"
                           data-rsvp-id={rsvp.id}
@@ -345,6 +370,35 @@ const statusClass: Record<string, string> = {
       document.querySelectorAll(".cancel-btn").forEach((btn) => {
         btn.addEventListener("click", () => {
           cancelRsvp(btn.dataset.rsvpId, btn.dataset.rsvpName, btn);
+        });
+      });
+
+      // Restore a cancelled RSVP
+      async function restoreRsvp(rsvpId, rsvpName, btn) {
+        if (!confirm(`Restore RSVP for ${rsvpName}?`)) return;
+        btn.disabled = true;
+        try {
+          const res = await fetch(`/api/admin/events/${id}/rsvp/restore`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ rsvp_id: parseInt(rsvpId, 10) }),
+          });
+          if (res.ok) {
+            window.location.reload();
+          } else {
+            alert("Failed to restore RSVP");
+            btn.disabled = false;
+          }
+        } catch (e) {
+          alert("Error: " + e.message);
+          btn.disabled = false;
+        }
+      }
+
+      document.querySelectorAll(".restore-btn").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          restoreRsvp(btn.dataset.rsvpId, btn.dataset.rsvpName, btn);
         });
       });
 


### PR DESCRIPTION
- Both RSVP endpoints (v1 and v2) now reactivate cancelled records instead of rejecting duplicate emails, preserving the unique constraint
- Add cancel_reason field to RSVP model ('admin_cancelled' | 'user_cancelled')
- Admin cancel sets cancel_reason = 'admin_cancelled'
- New POST /api/admin/events/{id}/rsvp/restore endpoint to restore cancelled RSVPs (to confirmed or waitlist based on capacity)
- Dashboard RSVP detail page shows 'Restore' button for cancelled RSVPs
- Cancel reason displayed next to status badge (by admin / by user)

Closes #109