### PR TITLE
feat: implement ride leader credit system

### DIFF
--- a/backend/migrations/004_add_ride_leader_credit_schema.sql
+++ b/backend/migrations/004_add_ride_leader_credit_schema.sql
@@ -1,0 +1,84 @@
+-- ============================================================
+-- Migration 004: Add ride leader credit schema
+-- ============================================================
+-- Adds:
+--   - events.distance_km
+--   - event_ride_leader_assignments
+--   - event_ride_leader_snapshots
+--   - event_ride_leader_credits
+--
+-- Run against PostgreSQL with:
+--   psql $DATABASE_URL -f backend/migrations/004_add_ride_leader_credit_schema.sql
+-- ============================================================
+
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS distance_km NUMERIC(8, 2);
+
+CREATE TABLE IF NOT EXISTS event_ride_leader_assignments (
+    id SERIAL PRIMARY KEY,
+    event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    rsvp_id INTEGER NOT NULL REFERENCES rsvps(id) ON DELETE CASCADE,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ NULL,
+    CONSTRAINT uq_event_ride_leader_assignment UNIQUE (event_id, rsvp_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_ride_leader_assignments_event
+    ON event_ride_leader_assignments(event_id);
+CREATE INDEX IF NOT EXISTS idx_event_ride_leader_assignments_active
+    ON event_ride_leader_assignments(event_id, is_active);
+
+CREATE TABLE IF NOT EXISTS event_ride_leader_snapshots (
+    id SERIAL PRIMARY KEY,
+    event_id INTEGER NOT NULL UNIQUE REFERENCES events(id) ON DELETE CASCADE,
+    distance_km NUMERIC(8, 2) NULL,
+    checked_in_count INTEGER NOT NULL DEFAULT 0,
+    group_size_cap INTEGER NOT NULL DEFAULT 6,
+    effective_group_count INTEGER NOT NULL DEFAULT 0,
+    credited_leader_count INTEGER NOT NULL DEFAULT 0,
+    max_credited_leader_count INTEGER NOT NULL DEFAULT 0,
+    credit_per_leader_km NUMERIC(8, 2) NULL,
+    total_credited_km NUMERIC(10, 2) NOT NULL DEFAULT 0,
+    calculated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    calculation_version VARCHAR(32) NOT NULL DEFAULT 'v1'
+);
+
+CREATE TABLE IF NOT EXISTS event_ride_leader_credits (
+    id SERIAL PRIMARY KEY,
+    event_id INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    rsvp_id INTEGER NOT NULL REFERENCES rsvps(id) ON DELETE CASCADE,
+    leader_name VARCHAR(100) NOT NULL,
+    credit_km NUMERIC(8, 2) NOT NULL,
+    distance_km NUMERIC(8, 2) NULL,
+    checked_in_count INTEGER NOT NULL DEFAULT 0,
+    effective_group_count INTEGER NOT NULL DEFAULT 0,
+    credited_leader_count INTEGER NOT NULL DEFAULT 0,
+    snapshot_id INTEGER NOT NULL REFERENCES event_ride_leader_snapshots(id) ON DELETE CASCADE,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ NULL,
+    CONSTRAINT uq_event_ride_leader_credit UNIQUE (event_id, rsvp_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_ride_leader_credits_event
+    ON event_ride_leader_credits(event_id);
+CREATE INDEX IF NOT EXISTS idx_event_ride_leader_credits_leader_name
+    ON event_ride_leader_credits(leader_name);
+CREATE INDEX IF NOT EXISTS idx_event_ride_leader_credits_active
+    ON event_ride_leader_credits(event_id, is_active);
+
+-- Verification queries
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_name = 'events'
+ORDER BY ordinal_position;
+
+SELECT table_name
+FROM information_schema.tables
+WHERE table_name IN (
+    'event_ride_leader_assignments',
+    'event_ride_leader_snapshots',
+    'event_ride_leader_credits'
+)
+ORDER BY table_name;

--- a/backend/models.py
+++ b/backend/models.py
@@ -5,6 +5,7 @@ Phase 4.3: Email-based event registration + subscription system
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from decimal import Decimal
 from sqlalchemy import (
     Column,
     Integer,
@@ -14,9 +15,9 @@ from sqlalchemy import (
     Boolean,
     Text,
     UniqueConstraint,
+    Numeric,
 )
 from sqlalchemy.orm import DeclarativeBase, relationship
-from sqlalchemy.dialects.postgresql import JSONB
 
 
 def _utcnow() -> datetime:
@@ -45,6 +46,7 @@ class Event(Base):
     max_participants = Column(Integer, nullable=True)
     current_participants = Column(Integer, default=0)
     registration_deadline = Column(DateTime(timezone=True), nullable=True)
+    distance_km = Column(Numeric(8, 2), nullable=True)
     is_public = Column(Boolean, default=True)
     created_at = Column(DateTime(timezone=True), default=_utcnow)
     updated_at = Column(
@@ -53,6 +55,22 @@ class Event(Base):
 
     rsvps = relationship(
         "RSVP", back_populates="event", cascade="all, delete-orphan",
+    )
+    ride_leader_assignments = relationship(
+        "EventRideLeaderAssignment",
+        back_populates="event",
+        cascade="all, delete-orphan",
+    )
+    ride_leader_snapshot = relationship(
+        "EventRideLeaderSnapshot",
+        back_populates="event",
+        cascade="all, delete-orphan",
+        uselist=False,
+    )
+    ride_leader_credits = relationship(
+        "EventRideLeaderCredit",
+        back_populates="event",
+        cascade="all, delete-orphan",
     )
 
     @property
@@ -102,12 +120,135 @@ class RSVP(Base):
     )
 
     event = relationship("Event", back_populates="rsvps")
+    ride_leader_assignments = relationship(
+        "EventRideLeaderAssignment",
+        back_populates="rsvp",
+        cascade="all, delete-orphan",
+    )
+    ride_leader_credits = relationship(
+        "EventRideLeaderCredit",
+        back_populates="rsvp",
+        cascade="all, delete-orphan",
+    )
 
     def __repr__(self) -> str:
         return (
             f"<RSVP(id={self.id}, event_id={self.event_id}, "
             f"email='{self.email}', status='{self.status}')>"
         )
+
+
+class EventRideLeaderAssignment(Base):
+    """Maps an RSVP to ride leader credit eligibility for one event."""
+
+    __tablename__ = "event_ride_leader_assignments"
+    __table_args__ = (
+        UniqueConstraint(
+            "event_id",
+            "rsvp_id",
+            name="uq_event_ride_leader_assignment",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    event_id = Column(
+        Integer,
+        ForeignKey("events.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    rsvp_id = Column(
+        Integer,
+        ForeignKey("rsvps.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=_utcnow, nullable=False)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+
+    event = relationship("Event", back_populates="ride_leader_assignments")
+    rsvp = relationship("RSVP", back_populates="ride_leader_assignments")
+
+
+class EventRideLeaderSnapshot(Base):
+    """Stores latest event-level ride leader credit calculation snapshot."""
+
+    __tablename__ = "event_ride_leader_snapshots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    event_id = Column(
+        Integer,
+        ForeignKey("events.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    distance_km = Column(Numeric(8, 2), nullable=True)
+    checked_in_count = Column(Integer, default=0, nullable=False)
+    group_size_cap = Column(Integer, default=6, nullable=False)
+    effective_group_count = Column(Integer, default=0, nullable=False)
+    credited_leader_count = Column(Integer, default=0, nullable=False)
+    max_credited_leader_count = Column(Integer, default=0, nullable=False)
+    credit_per_leader_km = Column(Numeric(8, 2), nullable=True)
+    total_credited_km = Column(
+        Numeric(10, 2), default=Decimal("0"), nullable=False,
+    )
+    calculated_at = Column(DateTime(timezone=True), default=_utcnow, nullable=False)
+    calculation_version = Column(String(32), default="v1", nullable=False)
+
+    event = relationship("Event", back_populates="ride_leader_snapshot")
+    credits = relationship(
+        "EventRideLeaderCredit",
+        back_populates="snapshot",
+        cascade="all, delete-orphan",
+    )
+
+
+class EventRideLeaderCredit(Base):
+    """Ledger rows for per-event per-leader credited mileage."""
+
+    __tablename__ = "event_ride_leader_credits"
+    __table_args__ = (
+        UniqueConstraint(
+            "event_id",
+            "rsvp_id",
+            name="uq_event_ride_leader_credit",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    event_id = Column(
+        Integer,
+        ForeignKey("events.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    rsvp_id = Column(
+        Integer,
+        ForeignKey("rsvps.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    leader_name = Column(String(100), nullable=False, index=True)
+    credit_km = Column(Numeric(8, 2), nullable=False)
+    distance_km = Column(Numeric(8, 2), nullable=True)
+    checked_in_count = Column(Integer, default=0, nullable=False)
+    effective_group_count = Column(Integer, default=0, nullable=False)
+    credited_leader_count = Column(Integer, default=0, nullable=False)
+    snapshot_id = Column(
+        Integer,
+        ForeignKey("event_ride_leader_snapshots.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), default=_utcnow, nullable=False)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+
+    event = relationship("Event", back_populates="ride_leader_credits")
+    rsvp = relationship("RSVP", back_populates="ride_leader_credits")
+    snapshot = relationship("EventRideLeaderSnapshot", back_populates="credits")
 
 
 class Subscriber(Base):

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -26,6 +26,17 @@ from services.event_counts import (
     get_available_spots,
     sync_event_current_participants,
 )
+from services.ride_leader_credits import (
+    get_annual_ride_leader_progress,
+    get_annual_ride_leader_summary,
+    get_event_active_leader_rsvp_ids,
+    get_event_ride_leader_credit_map,
+    get_ride_leader_detail,
+    mark_rsvp_as_ride_leader,
+    recalculate_event_ride_leader_state,
+    serialize_ride_leader_snapshot,
+    unmark_rsvp_as_ride_leader,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +59,9 @@ REQUIRED_SCHEMA_COLUMNS = {
         "cancel_reason",
         "checked_in_at",
     },
+    "events": {
+        "distance_km",
+    },
 }
 
 
@@ -60,11 +74,16 @@ class SyncOccurrenceRequest(BaseModel):
     max_participants: Optional[int] = None
     registration_deadline: Optional[datetime] = None
     description: Optional[str] = None
+    distance_km: Optional[float] = None
 
 
 class SyncOccurrencesResponse(BaseModel):
     created: int
     updated: int
+
+
+class RideLeaderRequest(BaseModel):
+    rsvp_id: int
 
 
 # ── Admin Schema Health ──────────────────────────────────────
@@ -126,8 +145,10 @@ def sync_occurrences(
                 event.event_type = occurrence.event_type
                 event.max_participants = occurrence.max_participants
                 event.registration_deadline = occurrence.registration_deadline
+                event.distance_km = occurrence.distance_km
                 event.is_public = True
                 updated += 1
+                recalculate_event_ride_leader_state(db, event.id)
                 continue
 
             db.add(
@@ -141,6 +162,7 @@ def sync_occurrences(
                     max_participants=occurrence.max_participants,
                     current_participants=0,
                     registration_deadline=occurrence.registration_deadline,
+                    distance_km=occurrence.distance_km,
                     is_public=True,
                 )
             )
@@ -194,6 +216,7 @@ def list_events(
                 event.registration_deadline.isoformat()
                 if event.registration_deadline else None
             ),
+            "distance_km": float(event.distance_km) if event.distance_km is not None else None,
         })
 
     return result
@@ -216,6 +239,9 @@ def get_event_rsvps(
         raise HTTPException(status_code=404, detail="Event not found")
 
     confirmed_count = sync_event_current_participants(db, event)
+    snapshot = recalculate_event_ride_leader_state(db, event_id)
+    active_leader_ids = get_event_active_leader_rsvp_ids(db, event_id)
+    credit_map = get_event_ride_leader_credit_map(db, event_id)
     db.commit()
     db.refresh(event)
 
@@ -226,6 +252,8 @@ def get_event_rsvps(
         .all()
     )
 
+    ride_leader_summary = serialize_ride_leader_snapshot(snapshot)
+
     return {
         "event": {
             "id": event.id,
@@ -235,6 +263,7 @@ def get_event_rsvps(
             "location": event.location,
             "max_participants": event.max_participants,
             "current_participants": confirmed_count,
+            "distance_km": float(event.distance_km) if event.distance_km is not None else None,
         },
         "rsvps": [
             {
@@ -251,6 +280,11 @@ def get_event_rsvps(
                 ),
                 "notes": r.notes,
                 "created_at": r.created_at.isoformat() if r.created_at else None,
+                "is_ride_leader": r.id in active_leader_ids,
+                "ride_leader_credit_km": (
+                    float(credit_map[r.id].credit_km)
+                    if r.id in credit_map else None
+                ),
             }
             for r in rsvps
         ],
@@ -263,6 +297,7 @@ def get_event_rsvps(
                 r for r in rsvps
                 if r.status == "confirmed" and r.checked_in_at
             ]),
+            **ride_leader_summary,
         },
     }
 
@@ -304,8 +339,10 @@ def check_in_rsvp(
 
     if not rsvp.checked_in_at:
         rsvp.checked_in_at = datetime.now(timezone.utc)
-        db.commit()
-        db.refresh(rsvp)
+
+    snapshot = recalculate_event_ride_leader_state(db, event_id)
+    db.commit()
+    db.refresh(rsvp)
 
     return {
         "success": True,
@@ -314,6 +351,7 @@ def check_in_rsvp(
         "checked_in_at": (
             rsvp.checked_in_at.isoformat() if rsvp.checked_in_at else None
         ),
+        "ride_leader_summary": serialize_ride_leader_snapshot(snapshot),
     }
 
 
@@ -348,14 +386,51 @@ def undo_check_in_rsvp(
 
     if rsvp.checked_in_at:
         rsvp.checked_in_at = None
-        db.commit()
-        db.refresh(rsvp)
+
+    snapshot = recalculate_event_ride_leader_state(db, event_id)
+    db.commit()
+    db.refresh(rsvp)
 
     return {
         "success": True,
         "message": f"Check-in for {rsvp.name} undone",
         "attendance_status": "registered",
         "checked_in_at": None,
+        "ride_leader_summary": serialize_ride_leader_snapshot(snapshot),
+    }
+
+
+# ── Admin Ride Leader Actions ────────────────────────────────
+
+@router.post("/api/admin/events/{event_id}/rsvp/ride-leader")
+def activate_ride_leader(
+    event_id: int,
+    body: RideLeaderRequest,
+    db: Session = Depends(get_db),
+    _admin: dict = Depends(get_current_admin),
+) -> dict:
+    snapshot = mark_rsvp_as_ride_leader(db, event_id, body.rsvp_id)
+    db.commit()
+    return {
+        "success": True,
+        "message": "Ride leader marked",
+        "ride_leader_summary": serialize_ride_leader_snapshot(snapshot),
+    }
+
+
+@router.post("/api/admin/events/{event_id}/rsvp/ride-leader/undo")
+def deactivate_ride_leader(
+    event_id: int,
+    body: RideLeaderRequest,
+    db: Session = Depends(get_db),
+    _admin: dict = Depends(get_current_admin),
+) -> dict:
+    snapshot = unmark_rsvp_as_ride_leader(db, event_id, body.rsvp_id)
+    db.commit()
+    return {
+        "success": True,
+        "message": "Ride leader removed",
+        "ride_leader_summary": serialize_ride_leader_snapshot(snapshot),
     }
 
 
@@ -416,6 +491,7 @@ def cancel_rsvp(
 
     db.flush()
     sync_event_current_participants(db, event)
+    recalculate_event_ride_leader_state(db, event_id)
     db.commit()
 
     # Send cancellation notification (non-fatal)
@@ -481,12 +557,43 @@ def restore_rsvp(
     rsvp.checked_in_at = None
     db.flush()
     sync_event_current_participants(db, event)
+    recalculate_event_ride_leader_state(db, event_id)
     db.commit()
 
     return {
         "success": True,
         "message": f"RSVP for {rsvp.name} restored to {new_status}",
         "new_status": new_status,
+    }
+
+
+# ── Annual Ride Leader Board ─────────────────────────────────
+
+@router.get("/api/admin/ride-leaders")
+def list_ride_leaders(
+    year: Optional[int] = None,
+    db: Session = Depends(get_db),
+    _admin: dict = Depends(get_current_admin),
+) -> dict:
+    target_year = year or datetime.now(timezone.utc).year
+    return {
+        "year": target_year,
+        "leaders": get_annual_ride_leader_summary(db, target_year),
+    }
+
+
+@router.get("/api/admin/ride-leaders/{leader_name}")
+def get_ride_leader(
+    leader_name: str,
+    year: Optional[int] = None,
+    db: Session = Depends(get_db),
+    _admin: dict = Depends(get_current_admin),
+) -> dict:
+    target_year = year or datetime.now(timezone.utc).year
+    detail = get_ride_leader_detail(db, target_year, leader_name)
+    return {
+        "year": target_year,
+        **detail,
     }
 
 
@@ -521,9 +628,14 @@ def export_rsvps_csv(
         "Status",
         "Attendance",
         "Checked In At",
+        "Ride Leader",
+        "Ride Leader Credit KM",
         "Notes",
         "Registered At",
     ])
+
+    credit_map = get_event_ride_leader_credit_map(db, event_id)
+    active_leader_ids = get_event_active_leader_rsvp_ids(db, event_id)
 
     for r in rsvps:
         writer.writerow([
@@ -532,6 +644,8 @@ def export_rsvps_csv(
             r.status,
             "checked_in" if r.checked_in_at else "registered",
             r.checked_in_at.isoformat() if r.checked_in_at else "",
+            "yes" if r.id in active_leader_ids else "no",
+            float(credit_map[r.id].credit_km) if r.id in credit_map else "",
             r.notes or "",
             r.created_at.isoformat() if r.created_at else "",
         ])

--- a/backend/routes/rsvp.py
+++ b/backend/routes/rsvp.py
@@ -72,6 +72,7 @@ class RSVPCreateV2(BaseModel):
     max_participants: Optional[int] = None
     registration_deadline: Optional[datetime] = None
     wechat_qr_code: Optional[str] = None
+    distance_km: Optional[float] = None
 
 
 class SubscribeRequest(BaseModel):
@@ -280,6 +281,7 @@ def create_rsvp_v2(
             event_type=data.event_type,
             max_participants=data.max_participants,
             registration_deadline=reg_deadline,
+            distance_km=data.distance_km,
         )
         db.add(event)
         db.flush()  # populate event.id before RSVP insert
@@ -291,6 +293,7 @@ def create_rsvp_v2(
         event.event_type = data.event_type
         event.max_participants = data.max_participants
         event.registration_deadline = reg_deadline
+        event.distance_km = data.distance_km
 
     # 2. Check registration deadline (guard against naive vs aware mismatch)
     if event.registration_deadline is not None:

--- a/backend/scripts/backfill_event_distances.py
+++ b/backend/scripts/backfill_event_distances.py
@@ -1,0 +1,176 @@
+"""Backfill structured event distance_km from markdown content.
+
+Usage:
+    python backend/scripts/backfill_event_distances.py [--write]
+
+Default is dry-run. The script scans zh event markdown as source-of-truth,
+extracts a high-confidence distance, maps recurring occurrences the same way as
+sync_events_from_markdown.py, and reports updated / skipped events.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+
+_backend_dir = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_backend_dir))
+
+import yaml
+from database import get_db
+from models import Event
+from services.recurring_events import parse_datetime, resolve_weekly_occurrence
+
+EVENTS_DIR = (
+    _backend_dir.parent / "frontend" / "src" / "content" / "events" / "zh"
+)
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---", re.DOTALL)
+_BODY_DISTANCE_PATTERNS = [
+    re.compile(r"全程约\s*(\d+(?:\.\d+)?)\s*km", re.IGNORECASE),
+    re.compile(r"路线[^\n|]*?(\d+(?:\.\d+)?)\s*km", re.IGNORECASE),
+    re.compile(r"约\s*(\d+(?:\.\d+)?)\s*km", re.IGNORECASE),
+]
+
+
+@dataclass
+class DistanceResolution:
+    slug: str
+    distance_km: Decimal | None
+    source: str | None
+    reason: str | None = None
+
+
+def _parse_markdown(path: Path) -> tuple[dict | None, str]:
+    text = path.read_text(encoding="utf-8")
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return None, text
+    return yaml.safe_load(match.group(1)), text[match.end():]
+
+
+def _to_decimal(value: float | int | str) -> Decimal:
+    return Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _extract_distance(frontmatter: dict, body: str) -> tuple[Decimal | None, str | None, str | None]:
+    if frontmatter.get("distanceKm") is not None:
+        return _to_decimal(frontmatter["distanceKm"]), "frontmatter.distanceKm", None
+
+    if frontmatter.get("routeDistanceKm") is not None:
+        return _to_decimal(frontmatter["routeDistanceKm"]), "frontmatter.routeDistanceKm", None
+
+    matches: list[tuple[Decimal, str]] = []
+    for pattern in _BODY_DISTANCE_PATTERNS:
+        for found in pattern.findall(body):
+            matches.append((_to_decimal(found), pattern.pattern))
+
+    unique_distances = sorted({value for value, _ in matches})
+    if len(unique_distances) == 1:
+        return unique_distances[0], "body", None
+    if len(unique_distances) > 1:
+        return None, None, f"ambiguous distances: {', '.join(str(v) for v in unique_distances)}"
+
+    return None, None, "no confident distance found"
+
+
+def resolve_markdown_distances() -> list[DistanceResolution]:
+    if not EVENTS_DIR.is_dir():
+        raise SystemExit(f"Events directory not found: {EVENTS_DIR}")
+
+    results: list[DistanceResolution] = []
+    for md_file in sorted(EVENTS_DIR.glob("*.md")):
+        frontmatter, body = _parse_markdown(md_file)
+        if frontmatter is None:
+            results.append(
+                DistanceResolution(
+                    slug=md_file.stem,
+                    distance_km=None,
+                    source=None,
+                    reason="missing frontmatter",
+                )
+            )
+            continue
+
+        source_slug = frontmatter.get("slug") or md_file.stem
+        event_date = parse_datetime(frontmatter["date"], "Europe/Berlin")
+        registration_deadline = (
+            parse_datetime(frontmatter["registrationDeadline"], "Europe/Berlin")
+            if frontmatter.get("registrationDeadline")
+            else None
+        )
+        occurrence = resolve_weekly_occurrence(
+            slug=source_slug,
+            event_date=event_date,
+            recurring=frontmatter.get("recurring") or {},
+            registration_deadline=registration_deadline,
+        )
+        resolved_slug = occurrence["slug"]
+
+        distance_km, source, reason = _extract_distance(frontmatter, body)
+        results.append(
+            DistanceResolution(
+                slug=resolved_slug,
+                distance_km=distance_km,
+                source=source,
+                reason=reason,
+            )
+        )
+
+    return results
+
+
+def run_backfill(write: bool = False) -> int:
+    results = resolve_markdown_distances()
+    db = next(get_db())
+
+    updated = 0
+    already_set = 0
+    skipped = 0
+
+    print(f"# Event distance backfill ({'write' if write else 'dry-run'})")
+
+    for result in results:
+        event = db.query(Event).filter(Event.slug == result.slug).first()
+        if event is None:
+            skipped += 1
+            print(f"SKIP {result.slug}: event missing in DB")
+            continue
+
+        if result.distance_km is None:
+            skipped += 1
+            print(f"SKIP {result.slug}: {result.reason}")
+            continue
+
+        current = None if event.distance_km is None else _to_decimal(event.distance_km)
+        if current == result.distance_km:
+            already_set += 1
+            print(f"KEEP {result.slug}: {result.distance_km} km ({result.source})")
+            continue
+
+        updated += 1
+        print(
+            f"{'WRITE' if write else 'PLAN '} {result.slug}: "
+            f"{current if current is not None else 'null'} -> {result.distance_km} km ({result.source})"
+        )
+        if write:
+            event.distance_km = result.distance_km
+
+    if write:
+        db.commit()
+    else:
+        db.rollback()
+
+    print(
+        f"\nSummary: updated={updated} already_set={already_set} skipped={skipped}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--write", action="store_true", help="Persist recovered distances")
+    args = parser.parse_args()
+    raise SystemExit(run_backfill(write=args.write))

--- a/backend/scripts/sync_events_from_markdown.py
+++ b/backend/scripts/sync_events_from_markdown.py
@@ -84,6 +84,9 @@ def sync() -> None:
         location = fm.get("location")
         event_type = fm.get("eventType", "social-ride")
         max_participants = fm.get("maxParticipants")
+        distance_km = fm.get("distanceKm")
+        if distance_km is None:
+            distance_km = fm.get("routeDistanceKm")
 
         existing = db.query(Event).filter(Event.slug == slug).first()
 
@@ -95,6 +98,7 @@ def sync() -> None:
             existing.event_type = event_type
             existing.max_participants = max_participants
             existing.registration_deadline = registration_deadline
+            existing.distance_km = distance_km
             existing.is_public = True
             print(f"  UPDATE: {slug}")
         else:
@@ -107,6 +111,7 @@ def sync() -> None:
                 event_type=event_type,
                 max_participants=max_participants,
                 registration_deadline=registration_deadline,
+                distance_km=distance_km,
                 current_participants=0,
                 is_public=True,
             )

--- a/backend/services/ride_leader_credits.py
+++ b/backend/services/ride_leader_credits.py
@@ -1,0 +1,500 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
+from math import ceil
+from typing import Iterable
+
+from fastapi import HTTPException
+from sqlalchemy import and_, func
+from sqlalchemy.orm import Session
+
+from models import (
+    Event,
+    EventRideLeaderAssignment,
+    EventRideLeaderCredit,
+    EventRideLeaderSnapshot,
+    RSVP,
+)
+
+GROUP_SIZE_CAP = 6
+REIMBURSEMENT_THRESHOLD_KM = Decimal("300")
+ANNUAL_TARGET_KM = Decimal("320")
+SUBSIDY_STEP_KM = Decimal("20")
+SUBSIDY_EURO_PER_STEP = Decimal("1")
+CALCULATION_VERSION = "v1"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _decimal(value: Decimal | float | int | None) -> Decimal | None:
+    if value is None:
+        return None
+    return Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+@dataclass
+class CreditSnapshotResult:
+    distance_km: Decimal | None
+    checked_in_count: int
+    group_size_cap: int
+    effective_group_count: int
+    credited_leader_count: int
+    max_credited_leader_count: int
+    credit_per_leader_km: Decimal | None
+    total_credited_km: Decimal
+
+
+def count_checked_in_confirmed_rsvps(db: Session, event_id: int) -> int:
+    return db.query(func.count(RSVP.id)).filter(
+        RSVP.event_id == event_id,
+        RSVP.status == "confirmed",
+        RSVP.checked_in_at.is_not(None),
+    ).scalar() or 0
+
+
+def compute_group_count(checked_in_count: int, group_size_cap: int = GROUP_SIZE_CAP) -> int:
+    if checked_in_count <= 0:
+        return 0
+    return ceil(checked_in_count / group_size_cap)
+
+
+def compute_max_credited_leaders(group_count: int) -> int:
+    return group_count * 2
+
+
+def compute_credit_snapshot(
+    distance_km: Decimal | float | int | None,
+    checked_in_count: int,
+    leader_count: int,
+    group_size_cap: int = GROUP_SIZE_CAP,
+) -> CreditSnapshotResult:
+    distance = _decimal(distance_km)
+    group_count = compute_group_count(checked_in_count, group_size_cap)
+    max_leaders = compute_max_credited_leaders(group_count)
+    total_credited_km = Decimal("0.00")
+    credit_per_leader = None
+
+    if distance is not None and group_count > 0:
+        total_credited_km = (distance * Decimal(group_count)).quantize(
+            Decimal("0.01"),
+            rounding=ROUND_HALF_UP,
+        )
+        if leader_count > 0:
+            credit_per_leader = (
+                total_credited_km / Decimal(leader_count)
+            ).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+    return CreditSnapshotResult(
+        distance_km=distance,
+        checked_in_count=checked_in_count,
+        group_size_cap=group_size_cap,
+        effective_group_count=group_count,
+        credited_leader_count=leader_count,
+        max_credited_leader_count=max_leaders,
+        credit_per_leader_km=credit_per_leader,
+        total_credited_km=total_credited_km,
+    )
+
+
+def _get_event_or_404(db: Session, event_id: int) -> Event:
+    event = db.query(Event).filter(Event.id == event_id).first()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+    return event
+
+
+def _get_rsvp_or_404(db: Session, event_id: int, rsvp_id: int) -> RSVP:
+    rsvp = db.query(RSVP).filter(
+        RSVP.id == rsvp_id,
+        RSVP.event_id == event_id,
+    ).first()
+    if rsvp is None:
+        raise HTTPException(status_code=404, detail="RSVP not found")
+    return rsvp
+
+
+def _is_rsvp_eligible(rsvp: RSVP) -> bool:
+    return rsvp.status == "confirmed" and rsvp.checked_in_at is not None
+
+
+def _get_or_create_snapshot(db: Session, event_id: int) -> EventRideLeaderSnapshot:
+    snapshot = db.query(EventRideLeaderSnapshot).filter(
+        EventRideLeaderSnapshot.event_id == event_id,
+    ).first()
+    if snapshot is None:
+        snapshot = EventRideLeaderSnapshot(event_id=event_id)
+        db.add(snapshot)
+        db.flush()
+    return snapshot
+
+
+def _active_assignments_for_event(db: Session, event_id: int) -> list[EventRideLeaderAssignment]:
+    return db.query(EventRideLeaderAssignment).filter(
+        EventRideLeaderAssignment.event_id == event_id,
+        EventRideLeaderAssignment.is_active.is_(True),
+    ).all()
+
+
+def _upsert_credit_row(
+    db: Session,
+    *,
+    snapshot: EventRideLeaderSnapshot,
+    assignment: EventRideLeaderAssignment,
+    credit_km: Decimal,
+) -> None:
+    credit = db.query(EventRideLeaderCredit).filter(
+        EventRideLeaderCredit.event_id == assignment.event_id,
+        EventRideLeaderCredit.rsvp_id == assignment.rsvp_id,
+    ).first()
+    if credit is None:
+        credit = EventRideLeaderCredit(
+            event_id=assignment.event_id,
+            rsvp_id=assignment.rsvp_id,
+        )
+        db.add(credit)
+
+    credit.leader_name = assignment.rsvp.name
+    credit.credit_km = credit_km
+    credit.distance_km = snapshot.distance_km
+    credit.checked_in_count = snapshot.checked_in_count
+    credit.effective_group_count = snapshot.effective_group_count
+    credit.credited_leader_count = snapshot.credited_leader_count
+    credit.snapshot_id = snapshot.id
+    credit.is_active = True
+    credit.revoked_at = None
+
+
+def revoke_invalid_leader_records_for_rsvp(db: Session, event_id: int, rsvp_id: int) -> bool:
+    changed = False
+    now = _utcnow()
+
+    assignment = db.query(EventRideLeaderAssignment).filter(
+        EventRideLeaderAssignment.event_id == event_id,
+        EventRideLeaderAssignment.rsvp_id == rsvp_id,
+        EventRideLeaderAssignment.is_active.is_(True),
+    ).first()
+    if assignment is not None:
+        assignment.is_active = False
+        assignment.revoked_at = now
+        changed = True
+
+    credit = db.query(EventRideLeaderCredit).filter(
+        EventRideLeaderCredit.event_id == event_id,
+        EventRideLeaderCredit.rsvp_id == rsvp_id,
+        EventRideLeaderCredit.is_active.is_(True),
+    ).first()
+    if credit is not None:
+        credit.is_active = False
+        credit.revoked_at = now
+        changed = True
+
+    return changed
+
+
+def recalculate_event_ride_leader_state(db: Session, event_id: int) -> CreditSnapshotResult:
+    event = _get_event_or_404(db, event_id)
+    snapshot = _get_or_create_snapshot(db, event_id)
+    checked_in_count = count_checked_in_confirmed_rsvps(db, event_id)
+    active_assignments = _active_assignments_for_event(db, event_id)
+
+    now = _utcnow()
+    valid_assignments: list[EventRideLeaderAssignment] = []
+    for assignment in active_assignments:
+        if _is_rsvp_eligible(assignment.rsvp):
+            valid_assignments.append(assignment)
+        else:
+            assignment.is_active = False
+            assignment.revoked_at = now
+
+    result = compute_credit_snapshot(
+        event.distance_km,
+        checked_in_count,
+        len(valid_assignments),
+    )
+
+    if len(valid_assignments) > result.max_credited_leader_count:
+        overflow = valid_assignments[result.max_credited_leader_count:]
+        valid_assignments = valid_assignments[:result.max_credited_leader_count]
+        for assignment in overflow:
+            assignment.is_active = False
+            assignment.revoked_at = now
+        result = compute_credit_snapshot(
+            event.distance_km,
+            checked_in_count,
+            len(valid_assignments),
+        )
+
+    snapshot.distance_km = result.distance_km
+    snapshot.checked_in_count = result.checked_in_count
+    snapshot.group_size_cap = result.group_size_cap
+    snapshot.effective_group_count = result.effective_group_count
+    snapshot.credited_leader_count = result.credited_leader_count
+    snapshot.max_credited_leader_count = result.max_credited_leader_count
+    snapshot.credit_per_leader_km = result.credit_per_leader_km
+    snapshot.total_credited_km = result.total_credited_km
+    snapshot.calculated_at = now
+    snapshot.calculation_version = CALCULATION_VERSION
+    db.flush()
+
+    valid_ids = {assignment.rsvp_id for assignment in valid_assignments}
+    active_credits = db.query(EventRideLeaderCredit).filter(
+        EventRideLeaderCredit.event_id == event_id,
+        EventRideLeaderCredit.is_active.is_(True),
+    ).all()
+    for credit in active_credits:
+        if credit.rsvp_id not in valid_ids:
+            credit.is_active = False
+            credit.revoked_at = now
+
+    if result.credit_per_leader_km is not None:
+        for assignment in valid_assignments:
+            _upsert_credit_row(
+                db,
+                snapshot=snapshot,
+                assignment=assignment,
+                credit_km=result.credit_per_leader_km,
+            )
+
+    return result
+
+
+def mark_rsvp_as_ride_leader(db: Session, event_id: int, rsvp_id: int) -> CreditSnapshotResult:
+    event = _get_event_or_404(db, event_id)
+    rsvp = _get_rsvp_or_404(db, event_id, rsvp_id)
+
+    if event.distance_km is None:
+        raise HTTPException(status_code=400, detail="Event distance_km is required")
+    if not _is_rsvp_eligible(rsvp):
+        raise HTTPException(
+            status_code=400,
+            detail="Only checked-in confirmed RSVPs can be marked as ride leader",
+        )
+
+    checked_in_count = count_checked_in_confirmed_rsvps(db, event_id)
+    group_count = compute_group_count(checked_in_count)
+    max_leaders = compute_max_credited_leaders(group_count)
+    if max_leaders <= 0:
+        raise HTTPException(status_code=400, detail="No checked-in participants")
+
+    assignment = db.query(EventRideLeaderAssignment).filter(
+        EventRideLeaderAssignment.event_id == event_id,
+        EventRideLeaderAssignment.rsvp_id == rsvp_id,
+    ).first()
+
+    active_count = db.query(func.count(EventRideLeaderAssignment.id)).filter(
+        EventRideLeaderAssignment.event_id == event_id,
+        EventRideLeaderAssignment.is_active.is_(True),
+    ).scalar() or 0
+
+    already_active = assignment is not None and assignment.is_active
+    if not already_active and active_count >= max_leaders:
+        raise HTTPException(status_code=400, detail="Ride leader cap exceeded")
+
+    if assignment is None:
+        assignment = EventRideLeaderAssignment(
+            event_id=event_id,
+            rsvp_id=rsvp_id,
+            is_active=True,
+        )
+        db.add(assignment)
+    else:
+        assignment.is_active = True
+        assignment.revoked_at = None
+
+    db.flush()
+    return recalculate_event_ride_leader_state(db, event_id)
+
+
+def unmark_rsvp_as_ride_leader(db: Session, event_id: int, rsvp_id: int) -> CreditSnapshotResult:
+    assignment = db.query(EventRideLeaderAssignment).filter(
+        EventRideLeaderAssignment.event_id == event_id,
+        EventRideLeaderAssignment.rsvp_id == rsvp_id,
+    ).first()
+    if assignment is not None and assignment.is_active:
+        assignment.is_active = False
+        assignment.revoked_at = _utcnow()
+
+    credit = db.query(EventRideLeaderCredit).filter(
+        EventRideLeaderCredit.event_id == event_id,
+        EventRideLeaderCredit.rsvp_id == rsvp_id,
+        EventRideLeaderCredit.is_active.is_(True),
+    ).first()
+    if credit is not None:
+        credit.is_active = False
+        credit.revoked_at = _utcnow()
+
+    db.flush()
+    return recalculate_event_ride_leader_state(db, event_id)
+
+
+def serialize_ride_leader_snapshot(
+    snapshot: CreditSnapshotResult | EventRideLeaderSnapshot | None,
+) -> dict:
+    if snapshot is None:
+        return {
+            "distance_km": None,
+            "checked_in_count": 0,
+            "effective_group_count": 0,
+            "credited_leader_count": 0,
+            "max_credited_leader_count": 0,
+            "credit_per_leader_km": None,
+            "total_credited_km": 0.0,
+        }
+
+    if isinstance(snapshot, CreditSnapshotResult):
+        return {
+            "distance_km": float(snapshot.distance_km) if snapshot.distance_km is not None else None,
+            "checked_in_count": snapshot.checked_in_count,
+            "effective_group_count": snapshot.effective_group_count,
+            "credited_leader_count": snapshot.credited_leader_count,
+            "max_credited_leader_count": snapshot.max_credited_leader_count,
+            "credit_per_leader_km": float(snapshot.credit_per_leader_km) if snapshot.credit_per_leader_km is not None else None,
+            "total_credited_km": float(snapshot.total_credited_km),
+        }
+
+    return {
+        "distance_km": float(snapshot.distance_km) if snapshot.distance_km is not None else None,
+        "checked_in_count": snapshot.checked_in_count,
+        "effective_group_count": snapshot.effective_group_count,
+        "credited_leader_count": snapshot.credited_leader_count,
+        "max_credited_leader_count": snapshot.max_credited_leader_count,
+        "credit_per_leader_km": float(snapshot.credit_per_leader_km) if snapshot.credit_per_leader_km is not None else None,
+        "total_credited_km": float(snapshot.total_credited_km),
+    }
+
+
+def get_event_ride_leader_credit_map(db: Session, event_id: int) -> dict[int, EventRideLeaderCredit]:
+    credits = db.query(EventRideLeaderCredit).filter(
+        EventRideLeaderCredit.event_id == event_id,
+        EventRideLeaderCredit.is_active.is_(True),
+    ).all()
+    return {credit.rsvp_id: credit for credit in credits}
+
+
+def get_event_active_leader_rsvp_ids(db: Session, event_id: int) -> set[int]:
+    rows = db.query(EventRideLeaderAssignment.rsvp_id).filter(
+        EventRideLeaderAssignment.event_id == event_id,
+        EventRideLeaderAssignment.is_active.is_(True),
+    ).all()
+    return {row[0] for row in rows}
+
+
+def get_annual_ride_leader_summary(db: Session, year: int) -> list[dict]:
+    start = datetime(year, 1, 1, tzinfo=timezone.utc)
+    end = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+
+    rows = db.query(EventRideLeaderCredit).join(Event).filter(
+        EventRideLeaderCredit.is_active.is_(True),
+        Event.event_date >= start,
+        Event.event_date < end,
+    ).order_by(Event.event_date.asc(), EventRideLeaderCredit.id.asc()).all()
+
+    grouped: dict[str, dict] = {}
+    for credit in rows:
+        info = grouped.setdefault(
+            credit.leader_name,
+            {
+                "leader_name": credit.leader_name,
+                "lead_events_count": 0,
+                "total_credited_km": Decimal("0.00"),
+            },
+        )
+        info["lead_events_count"] += 1
+        info["total_credited_km"] += _decimal(credit.credit_km) or Decimal("0.00")
+
+    result: list[dict] = []
+    for leader_name in sorted(grouped):
+        info = grouped[leader_name]
+        total = info["total_credited_km"].quantize(Decimal("0.01"))
+        excess = max(total - ANNUAL_TARGET_KM, Decimal("0.00"))
+        subsidy = (
+            (excess / SUBSIDY_STEP_KM).to_integral_value(rounding=ROUND_HALF_UP)
+            * SUBSIDY_EURO_PER_STEP
+            if excess > 0
+            else Decimal("0.00")
+        )
+        result.append(
+            {
+                "leader_name": leader_name,
+                "lead_events_count": info["lead_events_count"],
+                "total_credited_km": float(total),
+                "reimbursement_eligible": total >= REIMBURSEMENT_THRESHOLD_KM,
+                "annual_target_km": float(ANNUAL_TARGET_KM),
+                "excess_km": float(excess),
+                "estimated_subsidy_eur": float(subsidy),
+            }
+        )
+    return result
+
+
+def get_ride_leader_event_history(db: Session, year: int, leader_name: str) -> list[dict]:
+    start = datetime(year, 1, 1, tzinfo=timezone.utc)
+    end = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+    rows = db.query(EventRideLeaderCredit, Event).join(Event).filter(
+        EventRideLeaderCredit.is_active.is_(True),
+        EventRideLeaderCredit.leader_name == leader_name,
+        Event.event_date >= start,
+        Event.event_date < end,
+    ).order_by(Event.event_date.asc(), EventRideLeaderCredit.id.asc()).all()
+
+    history: list[dict] = []
+    for credit, event in rows:
+        history.append(
+            {
+                "event_id": event.id,
+                "event_slug": event.slug,
+                "event_title": event.title,
+                "event_date": event.event_date.isoformat() if event.event_date else None,
+                "distance_km": float(credit.distance_km) if credit.distance_km is not None else None,
+                "checked_in_count": credit.checked_in_count,
+                "effective_group_count": credit.effective_group_count,
+                "credited_leader_count": credit.credited_leader_count,
+                "credit_km": float(credit.credit_km),
+            }
+        )
+    return history
+
+
+def get_annual_ride_leader_progress(db: Session, year: int, leader_name: str) -> list[dict]:
+    history = get_ride_leader_event_history(db, year, leader_name)
+    cumulative = Decimal("0.00")
+    points: list[dict] = []
+    for row in history:
+        cumulative += _decimal(row["credit_km"]) or Decimal("0.00")
+        points.append(
+            {
+                "event_id": row["event_id"],
+                "event_date": row["event_date"],
+                "cumulative_km": float(cumulative.quantize(Decimal("0.01"))),
+                "credit_km": row["credit_km"],
+            }
+        )
+    return points
+
+
+def get_ride_leader_detail(db: Session, year: int, leader_name: str) -> dict:
+    history = get_ride_leader_event_history(db, year, leader_name)
+    progress = get_annual_ride_leader_progress(db, year, leader_name)
+    total = sum((Decimal(str(row["credit_km"])) for row in history), Decimal("0.00"))
+    excess = max(total - ANNUAL_TARGET_KM, Decimal("0.00"))
+    subsidy = (
+        (excess / SUBSIDY_STEP_KM).to_integral_value(rounding=ROUND_HALF_UP)
+        * SUBSIDY_EURO_PER_STEP
+        if excess > 0
+        else Decimal("0.00")
+    )
+    return {
+        "leader_name": leader_name,
+        "lead_events_count": len(history),
+        "total_credited_km": float(total.quantize(Decimal("0.01"))),
+        "reimbursement_eligible": total >= REIMBURSEMENT_THRESHOLD_KM,
+        "annual_target_km": float(ANNUAL_TARGET_KM),
+        "excess_km": float(excess),
+        "estimated_subsidy_eur": float(subsidy),
+        "progress": progress,
+        "history": history,
+    }

--- a/backend/tests/test_admin_ride_leader.py
+++ b/backend/tests/test_admin_ride_leader.py
@@ -125,7 +125,7 @@ class TestRideLeaderWorkflow:
         _mark_leader(client, sample_event.id, confirmed_rsvp.id)
 
         riders = []
-        for idx in range(2, 5):
+        for idx in range(2, 7):
             rsvp = RSVP(
                 event_id=sample_event.id,
                 email=f"leader{idx}@example.com",
@@ -139,13 +139,13 @@ class TestRideLeaderWorkflow:
             riders.append(rsvp)
         db.commit()
 
-        for rider in riders[:3]:
-            resp = _mark_leader(client, sample_event.id, rider.id)
-            if rider is riders[2]:
-                assert resp.status_code == 400
-                assert "cap" in resp.json()["detail"]
-            else:
-                assert resp.status_code == 200
+        # checked-in count = 6 => 1 group => max 2 credited leaders total
+        second_leader = _mark_leader(client, sample_event.id, riders[0].id)
+        third_leader = _mark_leader(client, sample_event.id, riders[1].id)
+
+        assert second_leader.status_code == 200
+        assert third_leader.status_code == 400
+        assert "cap" in third_leader.json()["detail"]
 
     def test_undo_check_in_auto_revokes_leader(self, client, db, sample_event, confirmed_rsvp):
         sample_event.distance_km = Decimal("48.50")

--- a/backend/tests/test_admin_ride_leader.py
+++ b/backend/tests/test_admin_ride_leader.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from models import EventRideLeaderAssignment, EventRideLeaderCredit, EventRideLeaderSnapshot, RSVP
+
+
+def _check_in(client, event_id: int, rsvp_id: int):
+    return client.post(
+        f"/api/admin/events/{event_id}/rsvp/check-in",
+        json={"rsvp_id": rsvp_id},
+    )
+
+
+def _mark_leader(client, event_id: int, rsvp_id: int):
+    return client.post(
+        f"/api/admin/events/{event_id}/rsvp/ride-leader",
+        json={"rsvp_id": rsvp_id},
+    )
+
+
+def _undo_leader(client, event_id: int, rsvp_id: int):
+    return client.post(
+        f"/api/admin/events/{event_id}/rsvp/ride-leader/undo",
+        json={"rsvp_id": rsvp_id},
+    )
+
+
+def _leader_summary(client, year: int):
+    return client.get(f"/api/admin/ride-leaders?year={year}")
+
+
+def _leader_detail(client, leader_name: str, year: int):
+    return client.get(f"/api/admin/ride-leaders/{leader_name}?year={year}")
+
+
+class TestRideLeaderWorkflow:
+    def test_checked_in_confirmed_rsvp_can_be_marked_leader(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("48.50")
+        db.commit()
+
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        resp = _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        assert resp.status_code == 200
+        db.refresh(confirmed_rsvp)
+        assignment = db.query(EventRideLeaderAssignment).filter_by(
+            event_id=sample_event.id,
+            rsvp_id=confirmed_rsvp.id,
+        ).first()
+        credit = db.query(EventRideLeaderCredit).filter_by(
+            event_id=sample_event.id,
+            rsvp_id=confirmed_rsvp.id,
+        ).first()
+        snapshot = db.query(EventRideLeaderSnapshot).filter_by(event_id=sample_event.id).first()
+
+        assert assignment is not None and assignment.is_active is True
+        assert credit is not None and credit.is_active is True
+        assert float(credit.credit_km) == 48.5
+        assert snapshot is not None
+        assert snapshot.checked_in_count == 1
+        assert snapshot.effective_group_count == 1
+        assert snapshot.credited_leader_count == 1
+
+    def test_unchecked_in_rsvp_cannot_be_marked_leader(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("48.50")
+        db.commit()
+
+        resp = _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        assert resp.status_code == 400
+        assert "checked-in confirmed" in resp.json()["detail"]
+
+    def test_waitlist_rsvp_cannot_be_marked_leader(self, client, db, sample_event, waitlisted_rsvp):
+        sample_event.distance_km = Decimal("48.50")
+        waitlisted_rsvp.checked_in_at = datetime.now(timezone.utc)
+        db.commit()
+
+        resp = _mark_leader(client, sample_event.id, waitlisted_rsvp.id)
+
+        assert resp.status_code == 400
+
+    def test_mark_leader_requires_distance(self, client, db, sample_event, confirmed_rsvp):
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+
+        resp = _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        assert resp.status_code == 400
+        assert "distance_km" in resp.json()["detail"]
+
+    def test_mark_leader_is_idempotent(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("48.50")
+        db.commit()
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+
+        first = _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+        second = _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert db.query(EventRideLeaderAssignment).count() == 1
+        assert db.query(EventRideLeaderCredit).count() == 1
+
+    def test_undo_leader_is_idempotent(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("48.50")
+        db.commit()
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        first = _undo_leader(client, sample_event.id, confirmed_rsvp.id)
+        second = _undo_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assignment = db.query(EventRideLeaderAssignment).first()
+        assert assignment is not None
+        assert assignment.is_active is False
+
+    def test_cap_enforcement_works(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("60.00")
+        sample_event.max_participants = 12
+        db.commit()
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        riders = []
+        for idx in range(2, 5):
+            rsvp = RSVP(
+                event_id=sample_event.id,
+                email=f"leader{idx}@example.com",
+                name=f"Leader {idx}",
+                status="confirmed",
+                privacy_accepted=True,
+                view_token=f"tok-{idx}",
+                checked_in_at=datetime.now(timezone.utc),
+            )
+            db.add(rsvp)
+            riders.append(rsvp)
+        db.commit()
+
+        for rider in riders[:3]:
+            resp = _mark_leader(client, sample_event.id, rider.id)
+            if rider is riders[2]:
+                assert resp.status_code == 400
+                assert "cap" in resp.json()["detail"]
+            else:
+                assert resp.status_code == 200
+
+    def test_undo_check_in_auto_revokes_leader(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("48.50")
+        db.commit()
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        undo_resp = client.post(
+            f"/api/admin/events/{sample_event.id}/rsvp/check-in/undo",
+            json={"rsvp_id": confirmed_rsvp.id},
+        )
+
+        assert undo_resp.status_code == 200
+        assignment = db.query(EventRideLeaderAssignment).first()
+        credit = db.query(EventRideLeaderCredit).first()
+        assert assignment.is_active is False
+        assert credit.is_active is False
+
+    def test_cancel_auto_revokes_leader(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("48.50")
+        db.commit()
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        cancel_resp = client.post(
+            f"/api/admin/events/{sample_event.id}/rsvp/cancel",
+            json={"rsvp_id": confirmed_rsvp.id},
+        )
+
+        assert cancel_resp.status_code == 200
+        assignment = db.query(EventRideLeaderAssignment).first()
+        credit = db.query(EventRideLeaderCredit).first()
+        assert assignment.is_active is False
+        assert credit.is_active is False
+
+    def test_restore_does_not_auto_recreate_leader_credit(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("48.50")
+        db.commit()
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+        client.post(f"/api/admin/events/{sample_event.id}/rsvp/cancel", json={"rsvp_id": confirmed_rsvp.id})
+
+        restore_resp = client.post(
+            f"/api/admin/events/{sample_event.id}/rsvp/restore",
+            json={"rsvp_id": confirmed_rsvp.id},
+        )
+        list_resp = client.get(f"/api/admin/events/{sample_event.id}/rsvps")
+
+        assert restore_resp.status_code == 200
+        assert list_resp.status_code == 200
+        restored = next(row for row in list_resp.json()["rsvps"] if row["id"] == confirmed_rsvp.id)
+        assert restored["is_ride_leader"] is False
+        assert restored["ride_leader_credit_km"] is None
+
+
+class TestRideLeaderReporting:
+    def test_annual_aggregation_by_name_and_history(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("40.00")
+        sample_event.event_date = datetime(2026, 4, 18, 10, 30, tzinfo=timezone.utc)
+        db.commit()
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        second_event = RSVP(
+            event_id=sample_event.id,
+            email="duplicate@example.com",
+            name=confirmed_rsvp.name,
+            status="confirmed",
+            privacy_accepted=True,
+            view_token="tok-dup",
+            checked_in_at=datetime.now(timezone.utc),
+        )
+        second_host = sample_event
+        db.add(second_event)
+        db.commit()
+
+        summary_resp = _leader_summary(client, 2026)
+        detail_resp = _leader_detail(client, confirmed_rsvp.name, 2026)
+
+        assert summary_resp.status_code == 200
+        assert detail_resp.status_code == 200
+        leaders = summary_resp.json()["leaders"]
+        assert any(leader["leader_name"] == confirmed_rsvp.name for leader in leaders)
+        detail = detail_resp.json()
+        assert detail["leader_name"] == confirmed_rsvp.name
+        assert detail["lead_events_count"] >= 1
+        assert len(detail["history"]) >= 1
+        assert len(detail["progress"]) >= 1

--- a/backend/tests/test_admin_ride_leader.py
+++ b/backend/tests/test_admin_ride_leader.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from decimal import Decimal
 
-from models import EventRideLeaderAssignment, EventRideLeaderCredit, EventRideLeaderSnapshot, RSVP
+from models import Event, EventRideLeaderAssignment, EventRideLeaderCredit, EventRideLeaderSnapshot, RSVP
+from services.ride_leader_credits import compute_credit_snapshot, compute_group_count
 
 
 def _check_in(client, event_id: int, rsvp_id: int):
@@ -33,6 +34,55 @@ def _leader_summary(client, year: int):
 
 def _leader_detail(client, leader_name: str, year: int):
     return client.get(f"/api/admin/ride-leaders/{leader_name}?year={year}")
+
+
+def _make_checked_in_rsvp(db, event_id: int, email: str, name: str) -> RSVP:
+    rsvp = RSVP(
+        event_id=event_id,
+        email=email,
+        name=name,
+        status="confirmed",
+        privacy_accepted=True,
+        view_token=f"tok-{email}",
+        checked_in_at=datetime.now(timezone.utc),
+    )
+    db.add(rsvp)
+    db.commit()
+    db.refresh(rsvp)
+    return rsvp
+
+
+class TestRideLeaderMath:
+    def test_group_count_boundaries(self):
+        assert compute_group_count(0) == 0
+        assert compute_group_count(1) == 1
+        assert compute_group_count(6) == 1
+        assert compute_group_count(7) == 2
+        assert compute_group_count(12) == 2
+        assert compute_group_count(13) == 3
+
+    def test_credit_snapshot_splits_distance_across_multiple_leaders(self):
+        snapshot = compute_credit_snapshot(
+            distance_km=Decimal("48.50"),
+            checked_in_count=7,
+            leader_count=2,
+        )
+
+        assert snapshot.effective_group_count == 2
+        assert snapshot.max_credited_leader_count == 4
+        assert snapshot.total_credited_km == Decimal("97.00")
+        assert snapshot.credit_per_leader_km == Decimal("48.50")
+
+    def test_credit_snapshot_rounds_fractional_split(self):
+        snapshot = compute_credit_snapshot(
+            distance_km=Decimal("50.00"),
+            checked_in_count=13,
+            leader_count=4,
+        )
+
+        assert snapshot.effective_group_count == 3
+        assert snapshot.total_credited_km == Decimal("150.00")
+        assert snapshot.credit_per_leader_km == Decimal("37.50")
 
 
 class TestRideLeaderWorkflow:
@@ -147,6 +197,47 @@ class TestRideLeaderWorkflow:
         assert third_leader.status_code == 400
         assert "cap" in third_leader.json()["detail"]
 
+    def test_multi_leader_credit_recalculates_when_second_leader_added(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("30.00")
+        db.commit()
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        second_rsvp = _make_checked_in_rsvp(db, sample_event.id, "leader2@example.com", "Leader 2")
+        for idx in range(3, 8):
+            _make_checked_in_rsvp(db, sample_event.id, f"rider{idx}@example.com", f"Rider {idx}")
+
+        first_resp = _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+        second_resp = _mark_leader(client, sample_event.id, second_rsvp.id)
+
+        assert first_resp.status_code == 200
+        assert second_resp.status_code == 200
+        credits = db.query(EventRideLeaderCredit).filter_by(event_id=sample_event.id, is_active=True).all()
+        assert len(credits) == 2
+        assert sorted(float(c.credit_km) for c in credits) == [30.0, 30.0]
+        snapshot = db.query(EventRideLeaderSnapshot).filter_by(event_id=sample_event.id).first()
+        assert snapshot.effective_group_count == 2
+        assert float(snapshot.total_credited_km) == 60.0
+        assert float(snapshot.credit_per_leader_km) == 30.0
+
+    def test_undo_leader_recalculates_remaining_credit(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("30.00")
+        db.commit()
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        second_rsvp = _make_checked_in_rsvp(db, sample_event.id, "leader2@example.com", "Leader 2")
+        for idx in range(3, 8):
+            _make_checked_in_rsvp(db, sample_event.id, f"rider{idx}@example.com", f"Rider {idx}")
+        _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+        _mark_leader(client, sample_event.id, second_rsvp.id)
+
+        undo_resp = _undo_leader(client, sample_event.id, second_rsvp.id)
+
+        assert undo_resp.status_code == 200
+        active_credits = db.query(EventRideLeaderCredit).filter_by(event_id=sample_event.id, is_active=True).all()
+        assert len(active_credits) == 1
+        assert float(active_credits[0].credit_km) == 60.0
+        snapshot = db.query(EventRideLeaderSnapshot).filter_by(event_id=sample_event.id).first()
+        assert snapshot.credited_leader_count == 1
+        assert float(snapshot.credit_per_leader_km) == 60.0
+
     def test_undo_check_in_auto_revokes_leader(self, client, db, sample_event, confirmed_rsvp):
         sample_event.distance_km = Decimal("48.50")
         db.commit()
@@ -200,6 +291,31 @@ class TestRideLeaderWorkflow:
         assert restored["is_ride_leader"] is False
         assert restored["ride_leader_credit_km"] is None
 
+    def test_cancel_restore_recheckin_remark_state_machine(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("42.00")
+        db.commit()
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        cancel_resp = client.post(
+            f"/api/admin/events/{sample_event.id}/rsvp/cancel",
+            json={"rsvp_id": confirmed_rsvp.id},
+        )
+        restore_resp = client.post(
+            f"/api/admin/events/{sample_event.id}/rsvp/restore",
+            json={"rsvp_id": confirmed_rsvp.id},
+        )
+        recheck_resp = _check_in(client, sample_event.id, confirmed_rsvp.id)
+        remark_resp = _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        assert cancel_resp.status_code == 200
+        assert restore_resp.status_code == 200
+        assert recheck_resp.status_code == 200
+        assert remark_resp.status_code == 200
+        active_credits = db.query(EventRideLeaderCredit).filter_by(event_id=sample_event.id, is_active=True).all()
+        assert len(active_credits) == 1
+        assert float(active_credits[0].credit_km) == 42.0
+
 
 class TestRideLeaderReporting:
     def test_annual_aggregation_by_name_and_history(self, client, db, sample_event, confirmed_rsvp):
@@ -208,19 +324,6 @@ class TestRideLeaderReporting:
         db.commit()
         _check_in(client, sample_event.id, confirmed_rsvp.id)
         _mark_leader(client, sample_event.id, confirmed_rsvp.id)
-
-        second_event = RSVP(
-            event_id=sample_event.id,
-            email="duplicate@example.com",
-            name=confirmed_rsvp.name,
-            status="confirmed",
-            privacy_accepted=True,
-            view_token="tok-dup",
-            checked_in_at=datetime.now(timezone.utc),
-        )
-        second_host = sample_event
-        db.add(second_event)
-        db.commit()
 
         summary_resp = _leader_summary(client, 2026)
         detail_resp = _leader_detail(client, confirmed_rsvp.name, 2026)
@@ -234,3 +337,97 @@ class TestRideLeaderReporting:
         assert detail["lead_events_count"] >= 1
         assert len(detail["history"]) >= 1
         assert len(detail["progress"]) >= 1
+
+    def test_same_name_aggregates_across_events_and_filters_year(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("50.00")
+        sample_event.event_date = datetime(2026, 4, 18, 10, 30, tzinfo=timezone.utc)
+        second_event = Event(
+            slug="second-ride-2026",
+            title="Second Ride 2026",
+            event_date=datetime(2026, 6, 1, 9, 0, tzinfo=timezone.utc),
+            location="Munich",
+            event_type="social-ride",
+            max_participants=12,
+            current_participants=0,
+            distance_km=Decimal("70.00"),
+        )
+        old_year_event = Event(
+            slug="old-ride-2025",
+            title="Old Ride 2025",
+            event_date=datetime(2025, 9, 1, 9, 0, tzinfo=timezone.utc),
+            location="Munich",
+            event_type="social-ride",
+            max_participants=12,
+            current_participants=0,
+            distance_km=Decimal("80.00"),
+        )
+        db.add_all([second_event, old_year_event])
+        db.commit()
+        db.refresh(second_event)
+        db.refresh(old_year_event)
+
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        second_rsvp = _make_checked_in_rsvp(db, second_event.id, "same-name-2@example.com", confirmed_rsvp.name)
+        old_year_rsvp = _make_checked_in_rsvp(db, old_year_event.id, "same-name-3@example.com", confirmed_rsvp.name)
+        _mark_leader(client, second_event.id, second_rsvp.id)
+        _mark_leader(client, old_year_event.id, old_year_rsvp.id)
+
+        summary_2026 = _leader_summary(client, 2026)
+        detail_2026 = _leader_detail(client, confirmed_rsvp.name, 2026)
+        summary_2025 = _leader_summary(client, 2025)
+
+        assert summary_2026.status_code == 200
+        assert detail_2026.status_code == 200
+        assert summary_2025.status_code == 200
+
+        leader_2026 = next(
+            leader for leader in summary_2026.json()["leaders"]
+            if leader["leader_name"] == confirmed_rsvp.name
+        )
+        assert leader_2026["lead_events_count"] == 2
+        assert leader_2026["total_credited_km"] == 120.0
+
+        detail = detail_2026.json()
+        assert detail["lead_events_count"] == 2
+        assert detail["total_credited_km"] == 120.0
+        assert [point["cumulative_km"] for point in detail["progress"]] == [50.0, 120.0]
+        assert len(detail["history"]) == 2
+
+        leader_2025 = next(
+            leader for leader in summary_2025.json()["leaders"]
+            if leader["leader_name"] == confirmed_rsvp.name
+        )
+        assert leader_2025["lead_events_count"] == 1
+        assert leader_2025["total_credited_km"] == 80.0
+
+    def test_reimbursement_and_subsidy_thresholds_are_reported(self, client, db, sample_event, confirmed_rsvp):
+        sample_event.distance_km = Decimal("320.00")
+        sample_event.event_date = datetime(2026, 5, 1, 9, 0, tzinfo=timezone.utc)
+        extra_event = Event(
+            slug="bonus-ride-2026",
+            title="Bonus Ride 2026",
+            event_date=datetime(2026, 7, 1, 9, 0, tzinfo=timezone.utc),
+            location="Munich",
+            event_type="social-ride",
+            max_participants=12,
+            current_participants=0,
+            distance_km=Decimal("40.00"),
+        )
+        db.add(extra_event)
+        db.commit()
+        db.refresh(extra_event)
+
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+        extra_rsvp = _make_checked_in_rsvp(db, extra_event.id, "bonus@example.com", confirmed_rsvp.name)
+        _mark_leader(client, extra_event.id, extra_rsvp.id)
+
+        detail_resp = _leader_detail(client, confirmed_rsvp.name, 2026)
+        assert detail_resp.status_code == 200
+        detail = detail_resp.json()
+        assert detail["total_credited_km"] == 360.0
+        assert detail["reimbursement_eligible"] is True
+        assert detail["excess_km"] == 40.0
+        assert detail["estimated_subsidy_eur"] == 2.0

--- a/backend/tests/test_rsvp_v2_sync.py
+++ b/backend/tests/test_rsvp_v2_sync.py
@@ -2,6 +2,7 @@ import pytest
 from datetime import datetime, timezone
 from models import Event
 
+
 def test_create_rsvp_v2_syncs_metadata(client_no_auth, db):
     """
     Verify that POST /api/rsvp (v2) correctly updates an existing event's 
@@ -36,6 +37,7 @@ def test_create_rsvp_v2_syncs_metadata(client_no_auth, db):
         "event_date": new_date_iso,
         "event_type": "training-camp",
         "max_participants": 25,
+        "distance_km": 48.5,
         "lang": "en"
     }
 
@@ -53,6 +55,7 @@ def test_create_rsvp_v2_syncs_metadata(client_no_auth, db):
     assert updated_event.location == new_location
     assert updated_event.event_type == "training-camp"
     assert updated_event.max_participants == 25
+    assert float(updated_event.distance_km) == 48.5
     
     # Verify exact time parsing (14:45 UTC)
     db_date = updated_event.event_date

--- a/backend/tests/test_sync_occurrences.py
+++ b/backend/tests/test_sync_occurrences.py
@@ -22,6 +22,7 @@ NORD_PAYLOAD = {
     "max_participants": 15,
     "registration_deadline": DEADLINE,
     "description": "每周四下班后出发的社交骑。",
+    "distance_km": 48.5,
 }
 
 SUD_PAYLOAD = {
@@ -55,6 +56,7 @@ class TestSyncOccurrencesInsert:
         assert event.location == NORD_PAYLOAD["location"]
         assert event.event_type == NORD_PAYLOAD["event_type"]
         assert event.max_participants == NORD_PAYLOAD["max_participants"]
+        assert float(event.distance_km) == NORD_PAYLOAD["distance_km"]
         assert event.is_public is True
 
     def test_returns_created_count(self, client):

--- a/frontend/src/components/EventRegistrationForm.tsx
+++ b/frontend/src/components/EventRegistrationForm.tsx
@@ -13,6 +13,7 @@ interface EventRegistrationFormProps {
     maxParticipants: number | null;
     registrationDeadline: string | null;
     wechatQrCode: string | null;
+    distanceKm: number | null;
     isACCOfficialRide: boolean;
     lang: Locale;
     apiUrl: string;
@@ -37,6 +38,7 @@ export function EventRegistrationForm({
     maxParticipants,
     registrationDeadline,
     wechatQrCode,
+    distanceKm,
     isACCOfficialRide,
     lang,
     apiUrl,
@@ -107,6 +109,7 @@ export function EventRegistrationForm({
                     max_participants: maxParticipants,
                     registration_deadline: registrationDeadline,
                     wechat_qr_code: wechatQrCode,
+                    distance_km: distanceKm,
                 }),
             });
 

--- a/frontend/src/content.config.ts
+++ b/frontend/src/content.config.ts
@@ -255,6 +255,8 @@ const eventsCollection = defineCollection({
     registrationLink: z.string().optional(),
     ACCOfficialRide: z.boolean().optional(),
     wechatQrCode: z.string().optional(),
+    distanceKm: z.number().optional(),
+    routeDistanceKm: z.number().optional(),
     // displaySections is the canonical frontmatter field for which sections of the events page this event appears in.
     // 'hero'     → featured carousel at the top (max 2-3 events)
     // 'upcoming' → upcoming events card grid
@@ -282,6 +284,7 @@ const eventsCollection = defineCollection({
     eventType: data.eventType || 'social-ride' as const,
     description: data.description || '',
     registrationDeadline: data.registrationDeadline?.toISOString() ?? null,
+    distanceKm: data.distanceKm ?? data.routeDistanceKm ?? undefined,
     displaySections: data.displaySections ?? [data.displaySection],
     routeKomootUrl: data.routeKomootUrl || undefined,
     routeStravaUrl: data.routeStravaUrl || undefined,

--- a/frontend/src/lib/admin/events.ts
+++ b/frontend/src/lib/admin/events.ts
@@ -40,6 +40,7 @@ export type AdminEventRow = {
   spots_remaining: number | null;
   db_id: number | null;
   in_db: boolean;
+  distance_km?: number | null;
 };
 
 const EVENT_TYPE_LABELS: Record<AdminEventType, string> = {

--- a/frontend/src/pages/[lang]/events/[slug].astro
+++ b/frontend/src/pages/[lang]/events/[slug].astro
@@ -147,6 +147,7 @@ const isACCOfficialRide = entry.data.ACCOfficialRide === true;
       data-max-participants={entry.data.maxParticipants != null ? String(entry.data.maxParticipants) : ''}
       data-registration-deadline={effectiveDeadline}
       data-wechat-qr-code={entry.data.wechatQrCode ?? ''}
+      data-distance-km={entry.data.distanceKm != null ? String(entry.data.distanceKm) : ''}
       data-acc-official-ride={isACCOfficialRide ? 'true' : ''}
       data-lang={lang}
       data-api-url={apiUrl}
@@ -177,6 +178,8 @@ const isACCOfficialRide = entry.data.ACCOfficialRide === true;
     const maxParticipants = maxParticipantsRaw ? parseInt(maxParticipantsRaw, 10) : null;
     const registrationDeadline = container.dataset.registrationDeadline || null;
     const wechatQrCode = container.dataset.wechatQrCode || null;
+    const distanceKmRaw = container.dataset.distanceKm;
+    const distanceKm = distanceKmRaw ? parseFloat(distanceKmRaw) : null;
     const isACCOfficialRide = container.dataset.accOfficialRide === 'true';
     const lang = (container.dataset.lang ?? 'zh') as Locale;
     const apiUrl = container.dataset.apiUrl ?? '';
@@ -196,6 +199,7 @@ const isACCOfficialRide = entry.data.ACCOfficialRide === true;
         maxParticipants,
         registrationDeadline,
         wechatQrCode,
+        distanceKm,
         isACCOfficialRide,
         lang,
         apiUrl,

--- a/frontend/src/pages/dashboard/api/events/[id]/rsvp/ride-leader.ts
+++ b/frontend/src/pages/dashboard/api/events/[id]/rsvp/ride-leader.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ params, request }) => {
+    const apiUrl =
+        import.meta.env.PUBLIC_API_URL ||
+        "https://acc-clubhub-events-ms.vercel.app";
+
+    const cookie = request.headers.get("cookie") || "";
+    const { id } = params;
+    const body = await request.text();
+
+    const upstream = await fetch(
+        `${apiUrl}/api/admin/events/${id}/rsvp/ride-leader`,
+        {
+            method: "POST",
+            headers: {
+                Cookie: cookie,
+                "Content-Type": "application/json",
+            },
+            body,
+        }
+    );
+
+    const data = await upstream.json();
+
+    return new Response(JSON.stringify(data), {
+        status: upstream.status,
+        headers: { "Content-Type": "application/json" },
+    });
+};

--- a/frontend/src/pages/dashboard/api/events/[id]/rsvp/ride-leader/undo.ts
+++ b/frontend/src/pages/dashboard/api/events/[id]/rsvp/ride-leader/undo.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ params, request }) => {
+    const apiUrl =
+        import.meta.env.PUBLIC_API_URL ||
+        "https://acc-clubhub-events-ms.vercel.app";
+
+    const cookie = request.headers.get("cookie") || "";
+    const { id } = params;
+    const body = await request.text();
+
+    const upstream = await fetch(
+        `${apiUrl}/api/admin/events/${id}/rsvp/ride-leader/undo`,
+        {
+            method: "POST",
+            headers: {
+                Cookie: cookie,
+                "Content-Type": "application/json",
+            },
+            body,
+        }
+    );
+
+    const data = await upstream.json();
+
+    return new Response(JSON.stringify(data), {
+        status: upstream.status,
+        headers: { "Content-Type": "application/json" },
+    });
+};

--- a/frontend/src/pages/dashboard/events/[id].astro
+++ b/frontend/src/pages/dashboard/events/[id].astro
@@ -37,6 +37,7 @@ if (isLocalPreview) {
       location: "Munich",
       max_participants: 15,
       current_participants: 2,
+      distance_km: 48.5,
     },
     rsvps: [
       {
@@ -44,11 +45,13 @@ if (isLocalPreview) {
         name: "Preview Confirmed Rider",
         email: "confirmed@example.com",
         status: "confirmed",
-        attendance_status: "registered",
-        checked_in_at: null,
+        attendance_status: "checked_in",
+        checked_in_at: "2026-04-24T12:10:00.000Z",
         cancel_reason: null,
         notes: "Needs a stable confirm modal",
         created_at: "2026-04-24T12:00:00.000Z",
+        is_ride_leader: true,
+        ride_leader_credit_km: 48.5,
       },
       {
         id: 102,
@@ -60,6 +63,8 @@ if (isLocalPreview) {
         cancel_reason: "admin_cancelled",
         notes: "",
         created_at: "2026-04-23T12:00:00.000Z",
+        is_ride_leader: false,
+        ride_leader_credit_km: null,
       },
     ],
     summary: {
@@ -67,7 +72,13 @@ if (isLocalPreview) {
       confirmed: 1,
       waitlist: 0,
       cancelled: 1,
-      checked_in: 0,
+      checked_in: 1,
+      distance_km: 48.5,
+      effective_group_count: 1,
+      credited_leader_count: 1,
+      max_credited_leader_count: 2,
+      credit_per_leader_km: 48.5,
+      total_credited_km: 48.5,
     },
   };
 } else {
@@ -105,6 +116,11 @@ function formatDate(dateStr: string | null): string {
   }
 }
 
+function formatKm(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return `${Number(value).toFixed(1)} km`;
+}
+
 ---
 
 <!doctype html>
@@ -121,7 +137,7 @@ function formatDate(dateStr: string | null): string {
         margin: 0;
         padding: 2rem;
       }
-      .container { max-width: 1100px; margin: 0 auto; }
+      .container { max-width: 1180px; margin: 0 auto; }
       .header {
         display: flex;
         justify-content: space-between;
@@ -147,20 +163,50 @@ function formatDate(dateStr: string | null): string {
       .event-meta { display: flex; gap: 2rem; flex-wrap: wrap; font-size: 0.9rem; color: #57606a; }
       .event-meta span { display: flex; align-items: center; gap: 0.3rem; }
       .summary-bar {
-        display: flex;
+        display: grid;
         gap: 1rem;
         margin-bottom: 1.5rem;
-        flex-wrap: wrap;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
       }
       .summary-card {
         background: white;
         border: 1px solid #d0d7de;
         border-radius: 6px;
-        padding: 1rem 1.5rem;
+        padding: 1rem 1.25rem;
         min-width: 120px;
       }
       .summary-card .label { font-size: 0.75rem; color: #57606a; text-transform: uppercase; letter-spacing: 0.05em; }
-      .summary-card .value { font-size: 1.75rem; font-weight: 700; color: #24292f; }
+      .summary-card .value { font-size: 1.55rem; font-weight: 700; color: #24292f; }
+      .ride-summary-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+      .ride-summary-card {
+        background: white;
+        border: 1px solid #d0d7de;
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+      }
+      .ride-summary-card h3 {
+        margin: 0 0 0.8rem;
+        font-size: 0.95rem;
+        color: #24292f;
+      }
+      .ride-summary-list {
+        display: grid;
+        gap: 0.5rem;
+        margin: 0;
+      }
+      .ride-summary-list div {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        font-size: 0.88rem;
+      }
+      .ride-summary-list dt { color: #57606a; }
+      .ride-summary-list dd { margin: 0; font-weight: 600; color: #24292f; }
       .actions { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; }
       .action-btn {
         display: inline-block;
@@ -205,6 +251,7 @@ function formatDate(dateStr: string | null): string {
         padding: 0.75rem 1rem;
         border-bottom: 1px solid #eaeef2;
         font-size: 0.9rem;
+        vertical-align: top;
       }
       tr:last-child td { border-bottom: none; }
       tr:hover td { background: #f6f8fa; }
@@ -220,59 +267,74 @@ function formatDate(dateStr: string | null): string {
       .badge-cancelled { background: #ffebe9; color: #cf222e; }
       .badge-registered { background: #ddf4ff; color: #0969da; }
       .badge-checked-in { background: #dafbe1; color: #1a7f37; }
-      .check-in-btn {
+      .badge-ride-leader { background: #ede9fe; color: #6d28d9; }
+      .row-state {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+        align-items: center;
+      }
+      .check-in-btn,
+      .undo-check-in-btn,
+      .cancel-btn,
+      .restore-btn,
+      .ride-leader-btn,
+      .undo-ride-leader-btn {
         padding: 0.25rem 0.6rem;
+        border-radius: 6px;
+        font-size: 0.75rem;
+        cursor: pointer;
+        transition: background 0.2s;
+        border: 1px solid transparent;
+      }
+      .check-in-btn {
         background: #ddf4ff;
         color: #0969da !important;
-        border: 1px solid #54aeff66;
-        border-radius: 6px;
-        font-size: 0.75rem;
-        cursor: pointer;
-        transition: background 0.2s;
+        border-color: #54aeff66;
       }
       .check-in-btn:hover { background: #b6e3ff; }
-      .check-in-btn:disabled { opacity: 0.5; cursor: not-allowed; }
       .undo-check-in-btn {
-        padding: 0.25rem 0.6rem;
         background: #fff8c5;
         color: #9a6700 !important;
-        border: 1px solid #d4a72c66;
-        border-radius: 6px;
-        font-size: 0.75rem;
-        cursor: pointer;
-        transition: background 0.2s;
+        border-color: #d4a72c66;
       }
       .undo-check-in-btn:hover { background: #f7e78b; }
-      .undo-check-in-btn:disabled { opacity: 0.5; cursor: not-allowed; }
       .cancel-btn {
-        padding: 0.25rem 0.6rem;
         background: #ffebe9;
         color: #cf222e !important;
-        border: 1px solid #ff818266;
-        border-radius: 6px;
-        font-size: 0.75rem;
-        cursor: pointer;
-        transition: background 0.2s;
+        border-color: #ff818266;
       }
       .cancel-btn:hover { background: #ffc9c9; }
-      .cancel-btn:disabled { opacity: 0.5; cursor: not-allowed; }
       .restore-btn {
-        padding: 0.25rem 0.6rem;
         background: #dafbe1;
         color: #1a7f37 !important;
-        border: 1px solid #4ac26b66;
-        border-radius: 6px;
-        font-size: 0.75rem;
-        cursor: pointer;
-        transition: background 0.2s;
+        border-color: #4ac26b66;
       }
       .restore-btn:hover { background: #a7f3d0; }
-      .restore-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+      .ride-leader-btn {
+        background: #ede9fe;
+        color: #6d28d9 !important;
+        border-color: #c4b5fd;
+      }
+      .ride-leader-btn:hover { background: #ddd6fe; }
+      .undo-ride-leader-btn {
+        background: #f5f3ff;
+        color: #6d28d9 !important;
+        border-color: #d8b4fe;
+      }
+      .undo-ride-leader-btn:hover { background: #ede9fe; }
+      .check-in-btn:disabled,
+      .undo-check-in-btn:disabled,
+      .cancel-btn:disabled,
+      .restore-btn:disabled,
+      .ride-leader-btn:disabled,
+      .undo-ride-leader-btn:disabled { opacity: 0.5; cursor: not-allowed; }
       .cancel-reason { font-size: 0.7rem; color: #8b949e; margin-left: 0.3rem; }
-      .notes { max-width: 200px; font-size: 0.8rem; color: #57606a; }
+      .notes { max-width: 220px; font-size: 0.8rem; color: #57606a; }
       .error { background: #ffebe9; border: 1px solid #ff818266; padding: 1rem; border-radius: 6px; color: #cf222e; margin-bottom: 1rem; }
       .empty { text-align: center; padding: 3rem; color: #57606a; }
       .email-cell { font-family: monospace; font-size: 0.85rem; }
+      .leader-credit { color: #6d28d9; font-size: 0.78rem; margin-top: 0.2rem; }
       #notify-status { font-size: 0.85rem; margin-left: 0.5rem; }
       .confirm-overlay {
         position: fixed;
@@ -355,6 +417,7 @@ function formatDate(dateStr: string | null): string {
               <span>📅 {formatDate(eventData.event.event_date)}</span>
               <span>📍 {eventData.event.location || "—"}</span>
               <span>👥 {eventData.event.current_participants}/{eventData.event.max_participants || "∞"}</span>
+              <span>📏 {formatKm(eventData.event.distance_km)}</span>
             </div>
           </div>
 
@@ -379,6 +442,25 @@ function formatDate(dateStr: string | null): string {
               <div class="label">Total</div>
               <div class="value">{eventData.summary.total}</div>
             </div>
+          </div>
+
+          <div class="ride-summary-grid">
+            <section class="ride-summary-card">
+              <h3>Ride Leader Summary</h3>
+              <dl class="ride-summary-list">
+                <div><dt>Distance</dt><dd>{formatKm(eventData.summary.distance_km)}</dd></div>
+                <div><dt>Checked-in</dt><dd>{eventData.summary.checked_in_count ?? 0}</dd></div>
+                <div><dt>Effective Groups</dt><dd>{eventData.summary.effective_group_count ?? 0}</dd></div>
+              </dl>
+            </section>
+            <section class="ride-summary-card">
+              <h3>Credit Status</h3>
+              <dl class="ride-summary-list">
+                <div><dt>Active Leaders</dt><dd>{eventData.summary.credited_leader_count ?? 0} / {eventData.summary.max_credited_leader_count ?? 0}</dd></div>
+                <div><dt>Credit / Leader</dt><dd>{formatKm(eventData.summary.credit_per_leader_km)}</dd></div>
+                <div><dt>Total Credited</dt><dd>{formatKm(eventData.summary.total_credited_km)}</dd></div>
+              </dl>
+            </section>
           </div>
 
           <div class="actions">
@@ -407,6 +489,7 @@ function formatDate(dateStr: string | null): string {
                   <th>Email</th>
                   <th>Status</th>
                   <th>Attendance</th>
+                  <th>Ride Leader</th>
                   <th>Notes</th>
                   <th>Registered</th>
                   <th>Actions</th>
@@ -431,6 +514,18 @@ function formatDate(dateStr: string | null): string {
                       </span>
                       {rsvp.checked_in_at && (
                         <div class="cancel-reason">{formatDate(rsvp.checked_in_at)}</div>
+                      )}
+                    </td>
+                    <td>
+                      <div class="row-state">
+                        {rsvp.is_ride_leader ? (
+                          <span class="badge badge-ride-leader">ride leader</span>
+                        ) : (
+                          <span style="color:#8b949e; font-size:0.8rem;">—</span>
+                        )}
+                      </div>
+                      {rsvp.ride_leader_credit_km != null && (
+                        <div class="leader-credit">{formatKm(rsvp.ride_leader_credit_km)}</div>
                       )}
                     </td>
                     <td class="notes">{rsvp.notes || "—"}</td>
@@ -465,6 +560,26 @@ function formatDate(dateStr: string | null): string {
                               id={`undo-check-in-btn-${rsvp.id}`}
                             >
                               Undo check-in
+                            </button>
+                          )}
+                          {rsvp.status === "confirmed" && rsvp.checked_in_at && !rsvp.is_ride_leader && (
+                            <button
+                              class="ride-leader-btn"
+                              data-rsvp-id={rsvp.id}
+                              data-rsvp-name={rsvp.name}
+                              id={`ride-leader-btn-${rsvp.id}`}
+                            >
+                              Ride Leader
+                            </button>
+                          )}
+                          {rsvp.is_ride_leader && (
+                            <button
+                              class="undo-ride-leader-btn"
+                              data-rsvp-id={rsvp.id}
+                              data-rsvp-name={rsvp.name}
+                              id={`undo-ride-leader-btn-${rsvp.id}`}
+                            >
+                              Undo Leader
                             </button>
                           )}
                           <button
@@ -619,6 +734,66 @@ function formatDate(dateStr: string | null): string {
         });
       });
 
+      async function markRideLeader(rsvpId, rsvpName, btn) {
+        const confirmed = await confirmAction({
+          title: "Mark ride leader",
+          message: `Credit ${rsvpName} as ride leader for this event?`,
+          confirmLabel: "Mark leader",
+        });
+        if (!confirmed) return;
+        btn.disabled = true;
+        try {
+          const res = await fetch(`/dashboard/api/events/${id}/rsvp/ride-leader`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ rsvp_id: parseInt(rsvpId, 10) }),
+          });
+          const data = await res.json();
+          if (!res.ok) throw new Error(data.detail || `${res.status}`);
+          window.location.reload();
+        } catch (e) {
+          alert("Failed to mark ride leader: " + e.message);
+          btn.disabled = false;
+        }
+      }
+
+      document.querySelectorAll(".ride-leader-btn").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          markRideLeader(btn.dataset.rsvpId, btn.dataset.rsvpName, btn);
+        });
+      });
+
+      async function undoRideLeader(rsvpId, rsvpName, btn) {
+        const confirmed = await confirmAction({
+          title: "Undo ride leader",
+          message: `Remove ride leader credit from ${rsvpName}?`,
+          confirmLabel: "Undo leader",
+        });
+        if (!confirmed) return;
+        btn.disabled = true;
+        try {
+          const res = await fetch(`/dashboard/api/events/${id}/rsvp/ride-leader/undo`, {
+            method: "POST",
+            credentials: "include",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ rsvp_id: parseInt(rsvpId, 10) }),
+          });
+          const data = await res.json();
+          if (!res.ok) throw new Error(data.detail || `${res.status}`);
+          window.location.reload();
+        } catch (e) {
+          alert("Failed to undo ride leader: " + e.message);
+          btn.disabled = false;
+        }
+      }
+
+      document.querySelectorAll(".undo-ride-leader-btn").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          undoRideLeader(btn.dataset.rsvpId, btn.dataset.rsvpName, btn);
+        });
+      });
+
       async function cancelRsvp(rsvpId, rsvpName, btn) {
         const confirmed = await confirmAction({
           title: "Cancel RSVP",
@@ -647,7 +822,6 @@ function formatDate(dateStr: string | null): string {
             }
             btn.style.display = "none";
 
-            // If a waitlisted RSVP was promoted, update their badge in the table
             if (data.promoted) {
               document.querySelectorAll(".badge-waitlist").forEach((b) => {
                 if (b.closest("tr")?.querySelector("td strong")?.textContent === data.promoted) {
@@ -657,8 +831,6 @@ function formatDate(dateStr: string | null): string {
               });
             }
 
-            // Reload the page to get accurate spot counts from the server
-            // (summary cards and event meta header can't be updated client-side reliably)
             window.location.reload();
           } else {
             alert("Failed to cancel RSVP");
@@ -676,7 +848,6 @@ function formatDate(dateStr: string | null): string {
         });
       });
 
-      // Restore a cancelled RSVP
       async function restoreRsvp(rsvpId, rsvpName, btn) {
         const confirmed = await confirmAction({
           title: "Restore RSVP",
@@ -710,7 +881,6 @@ function formatDate(dateStr: string | null): string {
         });
       });
 
-      // Notify all confirmed + waitlisted registrants
       document.getElementById("notify-btn")?.addEventListener("click", async () => {
         const btn = document.getElementById("notify-btn");
         const status = document.getElementById("notify-status");

--- a/frontend/src/pages/dashboard/events/index.astro
+++ b/frontend/src/pages/dashboard/events/index.astro
@@ -93,6 +93,7 @@ const occurrencePayload = zhEvents.map((e) => ({
   max_participants: e.data.maxParticipants ?? null,
   registration_deadline: e.data.registrationDeadline ?? null,
   description: e.data.description ?? null,
+  distance_km: e.data.distanceKm ?? null,
 }));
 
 if (isLocalPreview) {
@@ -157,6 +158,7 @@ const allMerged: AdminEventRow[] = zhEvents.map((e) => {
     spots_remaining: stats?.spots_remaining ?? null,
     db_id: stats?.id ?? null,
     in_db: !!stats,
+    distance_km: stats?.distance_km ?? (e.data.distanceKm ?? null),
   };
 });
 
@@ -191,6 +193,11 @@ function formatDate(dateStr: string | null): string {
   } catch {
     return dateStr;
   }
+}
+
+function formatKm(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return `${Number(value).toFixed(1)} km`;
 }
 
 function getViewUrl(view: AdminEventView): string {
@@ -292,6 +299,11 @@ function getCategoryUrl(category: AdminEventCategory): string {
         line-height: 1.35;
       }
       .spots-left {
+        color: #57606a;
+        font-size: 0.78rem;
+        margin-top: 0.2rem;
+      }
+      .distance-note {
         color: #57606a;
         font-size: 0.78rem;
         margin-top: 0.2rem;
@@ -459,6 +471,7 @@ function getCategoryUrl(category: AdminEventCategory): string {
                         ? "No capacity limit"
                         : `${event.spots_remaining ?? event.maxParticipants} spots left`}
                     </div>
+                    <div class="distance-note">Distance: {formatKm(event.distance_km)}</div>
                   </td>
                   <td>
                     {event.db_id ? (

--- a/frontend/src/pages/dashboard/index.astro
+++ b/frontend/src/pages/dashboard/index.astro
@@ -107,6 +107,10 @@ try {
           <h2>Events</h2>
           <p>View event list, manage RSVPs, export CSV</p>
         </a>
+        <a href="/dashboard/ride-leaders" class="nav-card">
+          <h2>Ride Leader Board</h2>
+          <p>Track annual ride leader credits, progress, and event history</p>
+        </a>
         <a href="/dashboard/subscribers" class="nav-card">
           <h2>Subscribers</h2>
           <p>Manage email subscribers, broadcast event announcements</p>

--- a/frontend/src/pages/dashboard/ride-leaders/index.astro
+++ b/frontend/src/pages/dashboard/ride-leaders/index.astro
@@ -1,0 +1,464 @@
+---
+export const prerender = false;
+
+const apiUrl = import.meta.env.PUBLIC_API_URL || "https://acc-clubhub-events-ms.vercel.app";
+const isLocalPreview = import.meta.env.DEV
+  && ["127.0.0.1", "localhost"].includes(Astro.url.hostname)
+  && Astro.url.searchParams.get("preview") === "1";
+
+const cookie = Astro.request.headers.get("cookie") || "";
+if (!isLocalPreview) {
+  try {
+    const meRes = await fetch(`${apiUrl}/auth/me`, {
+      headers: { "Cookie": cookie },
+    });
+    if (!meRes.ok) {
+      return Astro.redirect("/dashboard/login", 302);
+    }
+  } catch {
+    return Astro.redirect("/dashboard/login", 302);
+  }
+}
+
+const now = new Date();
+const requestedYear = Number(Astro.url.searchParams.get("year") || now.getUTCFullYear());
+const year = Number.isFinite(requestedYear) ? requestedYear : now.getUTCFullYear();
+const selectedLeader = Astro.url.searchParams.get("leader") || "";
+
+let summaryData = { year, leaders: [] as any[] };
+let detailData: any = null;
+let fetchError: string | null = null;
+
+if (isLocalPreview) {
+  summaryData = {
+    year,
+    leaders: [
+      {
+        leader_name: "Alice Zhang",
+        lead_events_count: 4,
+        total_credited_km: 186.5,
+        reimbursement_eligible: false,
+        annual_target_km: 320,
+        excess_km: 0,
+        estimated_subsidy_eur: 0,
+      },
+      {
+        leader_name: "Bob Li",
+        lead_events_count: 7,
+        total_credited_km: 332,
+        reimbursement_eligible: true,
+        annual_target_km: 320,
+        excess_km: 12,
+        estimated_subsidy_eur: 1,
+      },
+    ],
+  };
+  detailData = {
+    year,
+    leader_name: selectedLeader || "Bob Li",
+    lead_events_count: 7,
+    total_credited_km: 332,
+    reimbursement_eligible: true,
+    annual_target_km: 320,
+    excess_km: 12,
+    estimated_subsidy_eur: 1,
+    progress: [
+      { event_id: 1, event_date: `${year}-03-15T09:00:00Z`, cumulative_km: 45, credit_km: 45 },
+      { event_id: 2, event_date: `${year}-04-05T09:00:00Z`, cumulative_km: 102, credit_km: 57 },
+      { event_id: 3, event_date: `${year}-05-11T09:00:00Z`, cumulative_km: 175, credit_km: 73 },
+      { event_id: 4, event_date: `${year}-06-09T09:00:00Z`, cumulative_km: 245, credit_km: 70 },
+      { event_id: 5, event_date: `${year}-07-19T09:00:00Z`, cumulative_km: 332, credit_km: 87 },
+    ],
+    history: [
+      {
+        event_id: 5,
+        event_slug: "preview-alps-ride",
+        event_title: "Preview Alps Ride",
+        event_date: `${year}-07-19T09:00:00Z`,
+        distance_km: 87,
+        checked_in_count: 18,
+        effective_group_count: 3,
+        credited_leader_count: 3,
+        credit_km: 87,
+      },
+    ],
+  };
+} else {
+  try {
+    const summaryRes = await fetch(`${apiUrl}/api/admin/ride-leaders?year=${year}`, {
+      headers: { "Cookie": cookie },
+    });
+    if (summaryRes.ok) {
+      summaryData = await summaryRes.json();
+    } else if (summaryRes.status === 401) {
+      return Astro.redirect("/dashboard/login", 302);
+    } else {
+      fetchError = `Failed to fetch ride leader summary: ${summaryRes.status}`;
+    }
+
+    const leaderForDetail = selectedLeader || summaryData.leaders[0]?.leader_name;
+    if (leaderForDetail && !fetchError) {
+      const detailRes = await fetch(
+        `${apiUrl}/api/admin/ride-leaders/${encodeURIComponent(leaderForDetail)}?year=${year}`,
+        { headers: { "Cookie": cookie } }
+      );
+      if (detailRes.ok) {
+        detailData = await detailRes.json();
+      } else if (detailRes.status === 401) {
+        return Astro.redirect("/dashboard/login", 302);
+      } else {
+        fetchError = `Failed to fetch ride leader detail: ${detailRes.status}`;
+      }
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    fetchError = `Failed to load ride leader board: ${message}`;
+  }
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleDateString("en-GB", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatKm(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return `${Number(value).toFixed(1)} km`;
+}
+
+function buildLeaderUrl(leaderName: string): string {
+  const params = new URLSearchParams();
+  params.set("year", String(year));
+  params.set("leader", leaderName);
+  return `/dashboard/ride-leaders?${params.toString()}`;
+}
+
+function buildYearUrl(nextYear: number): string {
+  const params = new URLSearchParams();
+  params.set("year", String(nextYear));
+  if (selectedLeader) params.set("leader", selectedLeader);
+  return `/dashboard/ride-leaders?${params.toString()}`;
+}
+
+const chartPoints = detailData?.progress ?? [];
+const chartMax = Math.max(
+  320,
+  300,
+  ...chartPoints.map((point: any) => point.cumulative_km ?? 0),
+  1,
+);
+const chartWidth = Math.max(chartPoints.length - 1, 1);
+const polylinePoints = chartPoints.map((point: any, index: number) => {
+  const x = (index / chartWidth) * 100;
+  const y = 100 - ((point.cumulative_km ?? 0) / chartMax) * 100;
+  return `${x},${y}`;
+}).join(" ");
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ride Leader Board | ACC ClubHub Admin</title>
+    <style>
+      * { box-sizing: border-box; }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        background: #f6f8fa;
+        margin: 0;
+        padding: 2rem;
+      }
+      .container { max-width: 1200px; margin: 0 auto; }
+      .breadcrumb { margin-bottom: 1.5rem; }
+      .breadcrumb a { color: #0969da; text-decoration: none; font-size: 0.9rem; }
+      .breadcrumb a:hover { text-decoration: underline; }
+      .header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+      h1 { font-size: 1.5rem; margin: 0; color: #24292f; }
+      .year-switcher {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+      }
+      .year-link {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 2rem;
+        height: 2rem;
+        border-radius: 999px;
+        border: 1px solid #d0d7de;
+        background: white;
+        color: #24292f;
+        text-decoration: none;
+      }
+      .year-link:hover { background: #f6f8fa; }
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+      .summary-card {
+        background: white;
+        border: 1px solid #d0d7de;
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+      }
+      .summary-card .label {
+        font-size: 0.75rem;
+        color: #57606a;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .summary-card .value {
+        margin-top: 0.35rem;
+        font-size: 1.4rem;
+        font-weight: 700;
+        color: #24292f;
+      }
+      .error { background: #ffebe9; border: 1px solid #ff818266; padding: 1rem; border-radius: 6px; color: #cf222e; margin-bottom: 1rem; }
+      .panel {
+        background: white;
+        border: 1px solid #d0d7de;
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        margin-bottom: 1.5rem;
+      }
+      .panel h2 {
+        margin: 0 0 1rem;
+        font-size: 1.05rem;
+        color: #24292f;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th, td {
+        padding: 0.75rem 0.6rem;
+        border-bottom: 1px solid #eaeef2;
+        text-align: left;
+        font-size: 0.9rem;
+      }
+      th {
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #57606a;
+      }
+      tr:last-child td { border-bottom: none; }
+      .leader-link {
+        color: #0969da;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      .leader-link:hover { text-decoration: underline; }
+      .chart-shell {
+        border: 1px solid #d0d7de;
+        border-radius: 8px;
+        padding: 1rem;
+        background: linear-gradient(to top, #fafbfc 0%, white 100%);
+      }
+      .chart-meta {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin-bottom: 0.75rem;
+        color: #57606a;
+        font-size: 0.85rem;
+      }
+      .chart-svg {
+        width: 100%;
+        height: 280px;
+        overflow: visible;
+      }
+      .chart-empty {
+        color: #57606a;
+        padding: 2rem 0;
+      }
+      .history-layout {
+        display: grid;
+        grid-template-columns: 1.1fr 0.9fr;
+        gap: 1.5rem;
+      }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        padding: 0.2rem 0.55rem;
+        border-radius: 999px;
+        background: #eef1f5;
+        color: #57606a;
+        font-size: 0.78rem;
+        font-weight: 600;
+      }
+      .pill.good {
+        background: #dafbe1;
+        color: #1a7f37;
+      }
+      @media (max-width: 900px) {
+        body { padding: 1rem; }
+        .history-layout { grid-template-columns: 1fr; }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="breadcrumb">
+        <a href="/dashboard">&larr; Admin Dashboard</a>
+      </div>
+
+      <div class="header">
+        <h1>Ride Leader Board</h1>
+        <div class="year-switcher">
+          <a class="year-link" href={buildYearUrl(year - 1)} aria-label="Previous year">←</a>
+          <strong>{year}</strong>
+          <a class="year-link" href={buildYearUrl(year + 1)} aria-label="Next year">→</a>
+        </div>
+      </div>
+
+      {fetchError && <div class="error">{fetchError}</div>}
+
+      {detailData && (
+        <div class="summary-grid">
+          <div class="summary-card">
+            <div class="label">Selected Leader</div>
+            <div class="value">{detailData.leader_name}</div>
+          </div>
+          <div class="summary-card">
+            <div class="label">Lead Events</div>
+            <div class="value">{detailData.lead_events_count}</div>
+          </div>
+          <div class="summary-card">
+            <div class="label">Total Credited</div>
+            <div class="value">{formatKm(detailData.total_credited_km)}</div>
+          </div>
+          <div class="summary-card">
+            <div class="label">Reimbursement</div>
+            <div class="value">
+              <span class={`pill ${detailData.reimbursement_eligible ? 'good' : ''}`}>
+                {detailData.reimbursement_eligible ? 'Eligible' : 'In progress'}
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <section class="panel">
+        <h2>Annual Board</h2>
+        {summaryData.leaders.length === 0 ? (
+          <div class="chart-empty">No ride leader credits recorded for {year} yet.</div>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>Ride Leader</th>
+                <th>Lead Events</th>
+                <th>Total Credited</th>
+                <th>300 km Threshold</th>
+                <th>Annual Target</th>
+                <th>Excess</th>
+                <th>Estimated Subsidy</th>
+              </tr>
+            </thead>
+            <tbody>
+              {summaryData.leaders.map((leader: any) => (
+                <tr>
+                  <td>
+                    <a class="leader-link" href={buildLeaderUrl(leader.leader_name)}>
+                      {leader.leader_name}
+                    </a>
+                  </td>
+                  <td>{leader.lead_events_count}</td>
+                  <td>{formatKm(leader.total_credited_km)}</td>
+                  <td>
+                    <span class={`pill ${leader.reimbursement_eligible ? 'good' : ''}`}>
+                      {leader.reimbursement_eligible ? 'Reached' : 'Not yet'}
+                    </span>
+                  </td>
+                  <td>{formatKm(leader.annual_target_km)}</td>
+                  <td>{formatKm(leader.excess_km)}</td>
+                  <td>€{Number(leader.estimated_subsidy_eur ?? 0).toFixed(0)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      {detailData && (
+        <div class="history-layout">
+          <section class="panel">
+            <h2>{detailData.leader_name} · Cumulative Progress</h2>
+            <div class="chart-shell">
+              <div class="chart-meta">
+                <span>Threshold: 300 km</span>
+                <span>Target: {formatKm(detailData.annual_target_km)}</span>
+                <span>Total: {formatKm(detailData.total_credited_km)}</span>
+              </div>
+              {chartPoints.length === 0 ? (
+                <div class="chart-empty">No credited events for this ride leader in {year}.</div>
+              ) : (
+                <svg viewBox="0 0 100 100" preserveAspectRatio="none" class="chart-svg" aria-label="Ride leader cumulative credit chart">
+                  <line x1="0" y1="100" x2="100" y2="100" stroke="#d0d7de" stroke-width="1" />
+                  <line x1="0" y1={100 - (300 / chartMax) * 100} x2="100" y2={100 - (300 / chartMax) * 100} stroke="#cf222e" stroke-width="1" stroke-dasharray="2 2" />
+                  <line x1="0" y1={100 - ((detailData.annual_target_km ?? 320) / chartMax) * 100} x2="100" y2={100 - ((detailData.annual_target_km ?? 320) / chartMax) * 100} stroke="#9a6700" stroke-width="1" stroke-dasharray="3 2" />
+                  <polyline fill="none" stroke="#0969da" stroke-width="2.5" points={polylinePoints} />
+                  {chartPoints.map((point: any, index: number) => {
+                    const x = (index / chartWidth) * 100;
+                    const y = 100 - ((point.cumulative_km ?? 0) / chartMax) * 100;
+                    return <circle cx={x} cy={y} r="1.6" fill="#0969da" />;
+                  })}
+                </svg>
+              )}
+            </div>
+          </section>
+
+          <section class="panel">
+            <h2>{detailData.leader_name} · Event History</h2>
+            {detailData.history.length === 0 ? (
+              <div class="chart-empty">No event history available.</div>
+            ) : (
+              <table>
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Event</th>
+                    <th>Distance</th>
+                    <th>Checked-in</th>
+                    <th>Groups</th>
+                    <th>Leaders</th>
+                    <th>Credited</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {detailData.history.map((row: any) => (
+                    <tr>
+                      <td>{formatDate(row.event_date)}</td>
+                      <td>{row.event_title}</td>
+                      <td>{formatKm(row.distance_km)}</td>
+                      <td>{row.checked_in_count}</td>
+                      <td>{row.effective_group_count}</td>
+                      <td>{row.credited_leader_count}</td>
+                      <td>{formatKm(row.credit_km)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </section>
+        </div>
+      )}
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add `distance_km` event support, ride leader ledger schema, and historical distance backfill script
- implement backend ride leader credit calculation, admin APIs, auto-recalculation hooks, and annual reporting endpoints
- add dashboard ride leader controls, event summary block, annual board, cumulative chart, and event history drill-down

## Validation
- `python3 -m compileall backend`
- Reviewed `git diff origin/master...HEAD --stat`
- Could not run `pytest` / `vitest` locally because this environment currently lacks installed test dependencies (`pytest` module missing, `vitest` command missing)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event distance tracking—events now support optional distance metrics
  * Ride leader credit system—admins can mark checked-in attendees as ride leaders and track their credited kilometers based on group size
  * Ride leader leaderboard—new admin dashboard displaying annual ride leader summaries with performance progress and detailed event history

<!-- end of auto-generated comment: release notes by coderabbit.ai -->