### PR TITLE
fix: speed up dashboard events sync path

### DIFF
--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -148,7 +148,6 @@ def sync_occurrences(
                 event.distance_km = occurrence.distance_km
                 event.is_public = True
                 updated += 1
-                recalculate_event_ride_leader_state(db, event.id)
                 continue
 
             db.add(

--- a/backend/tests/test_sync_occurrences.py
+++ b/backend/tests/test_sync_occurrences.py
@@ -7,6 +7,8 @@ is implemented in routes/admin.py.
 
 import pytest
 from datetime import datetime, timezone
+from unittest.mock import patch
+
 from models import Event
 
 
@@ -145,6 +147,18 @@ class TestSyncOccurrencesUpsert:
 
         db.refresh(sample_event)
         assert sample_event.is_public is True
+
+
+class TestSyncOccurrencesPerformance:
+    def test_update_path_does_not_trigger_ride_leader_recalculation(self, client, db):
+        client.post("/api/admin/sync-occurrences", json=[NORD_PAYLOAD])
+
+        updated = {**NORD_PAYLOAD, "title": "Updated title"}
+        with patch("routes.admin.recalculate_event_ride_leader_state") as mock_recalc:
+            res = client.post("/api/admin/sync-occurrences", json=[updated])
+
+        assert res.status_code == 200
+        mock_recalc.assert_not_called()
 
 
 class TestSyncOccurrencesEdgeCases:


### PR DESCRIPTION
## Summary
- remove ride leader recalculation from admin occurrence sync updates
- keep occurrence sync focused on event metadata upsert so dashboard events page can load quickly in production
- preserve ride leader recalculation only on state-changing operations (check-in/undo, mark/unmark, cancel/restore)

## Context
PR #135 has already been merged. This PR contains the follow-up commit pushed afterward and still needs merge into `master`.

## Validation
- `cd backend && PYTHONPATH=. pytest tests/test_sync_occurrences.py tests/test_admin_ride_leader.py`
- `cd backend && PYTHONPATH=. pytest` → `99 passed`
