### PR TITLE
fix(auth): use direct dashboard email login

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,7 +30,7 @@ ALLOWED_ORIGINS=http://localhost:4321,https://acc-clubhub.vercel.app
 # Comma-separated ride leader email addresses allowed to access /dashboard
 ADMIN_EMAIL_ALLOWLIST=liu_su@hotmail.com,hiligen723@gmail.com,15990575011@163.com,gongmei.ma@proton.me,taoyue.yang@helmholtz-munich.de,sheng.yuan@hotmail.com,shenzhikuan619@gmail.com
 
-# Shared password required before a magic link can be sent
+# Shared password required before direct dashboard email login
 ADMIN_MAGIC_LINK_PASSWORD=replace-with-dashboard-password
 
 # Optional fallback: comma-separated GitHub usernames allowed to access /dashboard

--- a/backend/routes/auth.py
+++ b/backend/routes/auth.py
@@ -8,12 +8,11 @@ from typing import Optional
 
 import httpx
 import jwt
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, EmailStr
 
 from config import settings
-from services.email import send_admin_magic_link_email
 
 router = APIRouter()
 
@@ -23,12 +22,11 @@ GITHUB_API_URL = "https://api.github.com"
 
 JWT_ALGORITHM = "HS256"
 JWT_EXPIRY_HOURS = 24
-MAGIC_LINK_EXPIRY_MINUTES = 15
 STATE_EXPIRY_MINUTES = 10
 
 
-class MagicLinkRequest(BaseModel):
-    """Magic link login request payload."""
+class EmailLoginRequest(BaseModel):
+    """Email and password dashboard login request payload."""
 
     email: EmailStr
     password: str
@@ -77,7 +75,7 @@ def is_admin_email_allowed(email: str) -> bool:
     return _normalize_email(email) in _get_admin_email_allowlist()
 
 
-def is_magic_link_password_valid(password: str) -> bool:
+def is_dashboard_password_valid(password: str) -> bool:
     """Check whether the shared dashboard password matches configuration."""
     expected_password = settings.ADMIN_MAGIC_LINK_PASSWORD
     if not expected_password:
@@ -176,39 +174,6 @@ def get_github_user(access_token: str) -> dict:
         return response.json()
 
 
-def create_magic_link_token(email: str) -> str:
-    """Create a short-lived magic link token for an authorized admin email."""
-    secret = _get_session_secret()
-    now = int(time.time())
-    payload = {
-        "type": "admin_magic_link",
-        "email": _normalize_email(email),
-        "exp": now + (MAGIC_LINK_EXPIRY_MINUTES * 60),
-        "iat": now,
-    }
-    return jwt.encode(payload, secret, algorithm=JWT_ALGORITHM)
-
-
-def verify_magic_link_token(token: str) -> str:
-    """Verify a magic link token and return the authorized admin email."""
-    secret = _get_session_secret()
-    try:
-        payload = jwt.decode(token, secret, algorithms=[JWT_ALGORITHM])
-    except jwt.ExpiredSignatureError:
-        raise HTTPException(status_code=400, detail="Magic link expired")
-    except jwt.PyJWTError:
-        raise HTTPException(status_code=400, detail="Invalid magic link")
-
-    if payload.get("type") != "admin_magic_link":
-        raise HTTPException(status_code=400, detail="Invalid magic link")
-
-    email = payload.get("email")
-    if not isinstance(email, str) or not is_admin_email_allowed(email):
-        raise HTTPException(status_code=403, detail="Email is not authorized")
-
-    return _normalize_email(email)
-
-
 def create_jwt_session(
     admin_id: str,
     auth_provider: str,
@@ -274,22 +239,29 @@ def login(request: Request) -> RedirectResponse:
     return RedirectResponse(url=get_github_auth_url(redirect_to), status_code=302)
 
 
-@router.post("/auth/magic-link")
-def request_magic_link(payload: MagicLinkRequest) -> dict:
-    """Send a dashboard login magic link when the email is authorized."""
+@router.post("/auth/email-login")
+def email_login(payload: EmailLoginRequest, response: Response) -> dict:
+    """Create a dashboard session when email and shared password are valid."""
     email = _normalize_email(payload.email)
-    if not is_admin_email_allowed(email) or not is_magic_link_password_valid(
+    if not is_admin_email_allowed(email) or not is_dashboard_password_valid(
         payload.password,
     ):
         raise HTTPException(status_code=403, detail="Invalid login credentials")
 
-    token = create_magic_link_token(email)
-    frontend_url = settings.PUBLIC_FRONTEND_URL.rstrip("/")
-    magic_link = f"{frontend_url}/auth/callback?token={token}"
-    result = send_admin_magic_link_email(email=email, magic_link=magic_link)
-    if result.get("status") in {"skipped", "error"}:
-        raise HTTPException(status_code=503, detail="Could not send magic link")
-    return {"status": result.get("status", "sent")}
+    session_token = create_jwt_session(
+        admin_id=email,
+        auth_provider="email",
+        email=email,
+    )
+    response.set_cookie(
+        key="admin_session",
+        value=session_token,
+        max_age=JWT_EXPIRY_HOURS * 3600,
+        httponly=True,
+        samesite="lax",
+        secure=True,
+    )
+    return {"status": "authenticated", "redirect_to": "/dashboard/events"}
 
 
 @router.get("/auth/callback")
@@ -297,17 +269,9 @@ def callback(
     request: Request,
     code: Optional[str] = None,
     state: Optional[str] = None,
-    token: Optional[str] = None,
 ) -> RedirectResponse:
-    """Handle GitHub OAuth callbacks and email magic link callbacks."""
-    if token:
-        email = verify_magic_link_token(token)
-        session_token = create_jwt_session(
-            admin_id=email,
-            auth_provider="email",
-            email=email,
-        )
-    elif code and state:
+    """Handle GitHub OAuth callbacks."""
+    if code and state:
         if not _verify_state_token(state):
             raise HTTPException(
                 status_code=400,
@@ -334,7 +298,7 @@ def callback(
             github_user_id=github_user_id,
         )
     else:
-        raise HTTPException(status_code=400, detail="Missing login callback token")
+        raise HTTPException(status_code=400, detail="Missing GitHub callback token")
 
     response = RedirectResponse(url="/dashboard/events", status_code=302)
     response.set_cookie(

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -22,35 +22,6 @@ if settings.RESEND_API_KEY:
     resend.api_key = settings.RESEND_API_KEY
 
 
-def send_admin_magic_link_email(email: str, magic_link: str) -> dict:
-    """Send an admin dashboard magic link email."""
-    if not settings.RESEND_API_KEY:
-        logger.debug("Skipping admin magic link email (no RESEND_API_KEY): %s", email)
-        return {"status": "skipped", "reason": "no_api_key"}
-
-    html_body = f"""<div style="font-family: Arial, sans-serif; max-width: 600px;">
-<h2 style="color: #2A5CA6;">ACC ClubHub Admin Login</h2>
-<p>Use the link below to sign in to the ACC ClubHub admin dashboard.</p>
-<p><a href="{magic_link}">Sign in to dashboard</a></p>
-<p>This link expires in 15 minutes. If you did not request it, you can ignore
-this email.</p>
-{_CONTACT["en"]}
-</div>"""
-
-    params = {
-        "from": "ACC ClubHub <noreply@events.across-cc.de>",
-        "to": [email],
-        "subject": "ACC ClubHub admin login link",
-        "html": html_body,
-    }
-
-    try:
-        return resend.Emails.send(params)
-    except Exception as e:
-        logger.error("Failed to send admin magic link email: %s", e, exc_info=True)
-        return {"status": "error", "message": str(e)}
-
-
 def send_confirmation_email(
     user_email: str,
     user_name: str,

--- a/backend/tests/test_auth_admin_login.py
+++ b/backend/tests/test_auth_admin_login.py
@@ -1,5 +1,5 @@
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Response
 
 from routes import auth
 
@@ -43,88 +43,48 @@ def test_is_admin_email_allowed_matches_case_insensitively(monkeypatch):
     assert auth.is_admin_email_allowed(" Captain@Example.com ")
 
 
-def test_request_magic_link_rejects_unknown_email(monkeypatch):
+def test_email_login_rejects_unknown_email(monkeypatch):
     monkeypatch.setattr(auth.settings, "ADMIN_EMAIL_ALLOWLIST", "leader@example.com")
     monkeypatch.setattr(auth.settings, "ADMIN_MAGIC_LINK_PASSWORD", "secret")
 
     with pytest.raises(HTTPException) as exc_info:
-        auth.request_magic_link(
-            auth.MagicLinkRequest(email="unknown@example.com", password="secret"),
+        auth.email_login(
+            auth.EmailLoginRequest(email="unknown@example.com", password="secret"),
+            Response(),
         )
 
     assert exc_info.value.status_code == 403
     assert "Invalid login credentials" in exc_info.value.detail
 
 
-def test_request_magic_link_rejects_wrong_password(monkeypatch):
+def test_email_login_rejects_wrong_password(monkeypatch):
     monkeypatch.setattr(auth.settings, "ADMIN_EMAIL_ALLOWLIST", "leader@example.com")
     monkeypatch.setattr(auth.settings, "ADMIN_MAGIC_LINK_PASSWORD", "secret")
 
     with pytest.raises(HTTPException) as exc_info:
-        auth.request_magic_link(
-            auth.MagicLinkRequest(email="leader@example.com", password="wrong"),
+        auth.email_login(
+            auth.EmailLoginRequest(email="leader@example.com", password="wrong"),
+            Response(),
         )
 
     assert exc_info.value.status_code == 403
     assert "Invalid login credentials" in exc_info.value.detail
 
 
-def test_request_magic_link_sends_email_for_allowlisted_address(monkeypatch):
-    sent = {}
+def test_email_login_sets_24_hour_session_for_allowlisted_address(monkeypatch):
     monkeypatch.setattr(auth.settings, "ADMIN_SESSION_SECRET", "test-secret")
     monkeypatch.setattr(auth.settings, "ADMIN_EMAIL_ALLOWLIST", "leader@example.com")
     monkeypatch.setattr(auth.settings, "ADMIN_MAGIC_LINK_PASSWORD", "secret")
-    monkeypatch.setattr(
-        auth.settings,
-        "PUBLIC_FRONTEND_URL",
-        "https://www.across-cc.de",
+
+    response = Response()
+    result = auth.email_login(
+        auth.EmailLoginRequest(email="Leader@Example.com", password="secret"),
+        response,
     )
 
-    def fake_send(email: str, magic_link: str) -> dict:
-        sent["email"] = email
-        sent["magic_link"] = magic_link
-        return {"status": "sent"}
-
-    monkeypatch.setattr(auth, "send_admin_magic_link_email", fake_send)
-
-    response = auth.request_magic_link(
-        auth.MagicLinkRequest(email="Leader@Example.com", password="secret"),
-    )
-
-    assert response == {"status": "sent"}
-    assert sent["email"] == "leader@example.com"
-    assert sent["magic_link"].startswith("https://www.across-cc.de/auth/callback")
-    assert "token=" in sent["magic_link"]
-
-
-def test_request_magic_link_fails_when_email_cannot_send(monkeypatch):
-    monkeypatch.setattr(auth.settings, "ADMIN_SESSION_SECRET", "test-secret")
-    monkeypatch.setattr(auth.settings, "ADMIN_EMAIL_ALLOWLIST", "leader@example.com")
-    monkeypatch.setattr(auth.settings, "ADMIN_MAGIC_LINK_PASSWORD", "secret")
-    monkeypatch.setattr(
-        auth,
-        "send_admin_magic_link_email",
-        lambda email, magic_link: {"status": "error"},
-    )
-
-    with pytest.raises(HTTPException) as exc_info:
-        auth.request_magic_link(
-            auth.MagicLinkRequest(email="leader@example.com", password="secret"),
-        )
-
-    assert exc_info.value.status_code == 503
-
-
-def test_magic_link_callback_sets_email_session(monkeypatch):
-    monkeypatch.setattr(auth.settings, "ADMIN_SESSION_SECRET", "test-secret")
-    monkeypatch.setattr(auth.settings, "ADMIN_EMAIL_ALLOWLIST", "leader@example.com")
-
-    token = auth.create_magic_link_token("Leader@Example.com")
-    response = auth.callback(request=None, token=token)
-
-    assert response.status_code == 302
-    assert response.headers["location"] == "/dashboard/events"
+    assert result == {"status": "authenticated", "redirect_to": "/dashboard/events"}
     assert "admin_session=" in response.headers["set-cookie"]
+    assert "Max-Age=86400" in response.headers["set-cookie"]
 
 
 def test_email_session_is_revoked_when_email_removed(monkeypatch):

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -14,8 +14,8 @@ Copy `backend/.env.example` to `backend/.env` and fill in your values. Never com
 | `RESEND_API_KEY` | Yes | Resend email service API key | `re_xxxxxxxxxxxxx` |
 | `ALLOWED_ORIGINS` | Yes | Comma-separated list of allowed CORS origins | `http://localhost:4321,https://acc-clubhub.vercel.app` |
 | `ADMIN_SESSION_SECRET` | Yes | Secret used to sign admin session cookies | `replace-with-a-long-random-secret` |
-| `ADMIN_EMAIL_ALLOWLIST` | Yes | Comma-separated ride leader emails allowed to access `/dashboard` by magic link | `liu_su@hotmail.com,hiligen723@gmail.com,15990575011@163.com,gongmei.ma@proton.me,taoyue.yang@helmholtz-munich.de,sheng.yuan@hotmail.com,shenzhikuan619@gmail.com` |
-| `ADMIN_MAGIC_LINK_PASSWORD` | Yes | Shared password required before a dashboard magic link can be sent | `replace-with-dashboard-password` |
+| `ADMIN_EMAIL_ALLOWLIST` | Yes | Comma-separated ride leader emails allowed to access `/dashboard` by email login | `liu_su@hotmail.com,hiligen723@gmail.com,15990575011@163.com,gongmei.ma@proton.me,taoyue.yang@helmholtz-munich.de,sheng.yuan@hotmail.com,shenzhikuan619@gmail.com` |
+| `ADMIN_MAGIC_LINK_PASSWORD` | Yes | Shared password required before direct dashboard email login | `replace-with-dashboard-password` |
 | `ADMIN_GITHUB_ALLOWLIST` | No | Optional fallback GitHub usernames allowed to access `/dashboard` | `genli3202,rideleader1` |
 | `GITHUB_CLIENT_ID` | No | Optional fallback GitHub OAuth App client ID | `Ov23lixxxxxxxxxxxxxx` |
 | `GITHUB_CLIENT_SECRET` | No | Optional fallback GitHub OAuth App client secret | `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` |
@@ -26,7 +26,7 @@ Copy `backend/.env.example` to `backend/.env` and fill in your values. Never com
 
 - **DATABASE_URL**: Vercel Dashboard → Storage → your Postgres instance → `.env` tab
 - **RESEND_API_KEY**: [resend.com/api-keys](https://resend.com/api-keys)
-- **Dashboard magic link auth**: configure `ADMIN_EMAIL_ALLOWLIST` in the
+- **Dashboard email login**: configure `ADMIN_EMAIL_ALLOWLIST` in the
   backend Vercel project with a comma-separated list of ride leader emails.
   Configure `ADMIN_MAGIC_LINK_PASSWORD` in the same backend project.
 - **GitHub OAuth**: GitHub Developer settings → OAuth Apps. Callback URL:

--- a/frontend/src/pages/dashboard/login.astro
+++ b/frontend/src/pages/dashboard/login.astro
@@ -199,14 +199,18 @@ try {
     </div>
 
     <script>
-      const form = document.getElementById("email-login-form");
+      const formElement = document.getElementById("email-login-form");
       const message = document.getElementById("login-message");
 
-      form?.addEventListener("submit", async (event) => {
+      if (!(formElement instanceof HTMLFormElement)) {
+        throw new Error("Dashboard login form was not found.");
+      }
+
+      formElement.addEventListener("submit", async (event) => {
         event.preventDefault();
 
-        const submit = form.querySelector("button[type='submit']");
-        const formData = new FormData(form);
+        const submit = formElement.querySelector("button[type='submit']");
+        const formData = new FormData(formElement);
         const email = formData.get("email");
         const password = formData.get("password");
         if (

--- a/frontend/src/pages/dashboard/login.astro
+++ b/frontend/src/pages/dashboard/login.astro
@@ -1,5 +1,5 @@
 ---
-// dashboard/login.astro - Admin magic link login page (SSR)
+// dashboard/login.astro - Admin direct email login page (SSR)
 export const prerender = false;
 
 const apiUrl = import.meta.env.PUBLIC_API_URL || "https://acc-clubhub-events-ms.vercel.app";
@@ -164,7 +164,7 @@ try {
       <h1>ACC ClubHub Admin</h1>
       <p>Enter an authorized ride leader email and dashboard password.</p>
 
-      <form id="magic-link-form">
+      <form id="email-login-form">
         <label for="admin-email">Email address</label>
         <input
           id="admin-email"
@@ -182,7 +182,7 @@ try {
           required
         />
         <button type="submit" class="login-btn login-btn--primary">
-          Send magic link
+          Sign in
         </button>
       </form>
 
@@ -199,7 +199,7 @@ try {
     </div>
 
     <script>
-      const form = document.getElementById("magic-link-form");
+      const form = document.getElementById("email-login-form");
       const message = document.getElementById("login-message");
 
       form?.addEventListener("submit", async (event) => {
@@ -218,32 +218,34 @@ try {
         }
 
         submit.disabled = true;
-        submit.textContent = "Sending...";
+        submit.textContent = "Signing in...";
         message?.classList.remove("is-visible", "message--success", "message--error");
 
         try {
-          const response = await fetch("/auth/magic-link", {
+          const response = await fetch("/auth/email-login", {
             method: "POST",
+            credentials: "same-origin",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ email, password }),
           });
 
           if (!response.ok) {
-            throw new Error("Unable to send login link.");
+            throw new Error("Unable to sign in.");
           }
 
-          if (message) {
-            message.textContent = "Check your email for the dashboard login link.";
-            message.classList.add("is-visible", "message--success");
-          }
+          const result = await response.json();
+          window.location.href = result.redirect_to || "/dashboard/events";
         } catch {
           if (message) {
-            message.textContent = "The email or password is incorrect, or the link could not be sent.";
+            message.textContent = "The email or password is incorrect.";
             message.classList.add("is-visible", "message--error");
           }
-        } finally {
           submit.disabled = false;
-          submit.textContent = "Send magic link";
+          submit.textContent = "Sign in";
+        } finally {
+          if (!submit.disabled) {
+            submit.textContent = "Sign in";
+          }
         }
       });
     </script>

--- a/progress.md
+++ b/progress.md
@@ -193,9 +193,9 @@
   - [X] Reconciled `current_participants` from confirmed RSVP rows after admin cancel/restore and public registration changes.
   - [X] Cleared `checked_in_at` when an RSVP is cancelled so cancelled participants no longer count as checked in.
   - [X] Public event responses now calculate available spots from confirmed RSVPs to avoid stale or negative counters.
-- [X] **Dashboard Magic Link Admin Auth** (2026-04-29)
-  - [X] Added email allowlist magic link login for ride leader dashboard access.
-  - [X] Required a shared dashboard password before magic links are sent.
+- [X] **Dashboard Email Password Admin Auth** (2026-04-29)
+  - [X] Added email allowlist login for ride leader dashboard access.
+  - [X] Required a shared dashboard password before creating a 24-hour session.
   - [X] Kept GitHub OAuth allowlist login as a fallback during migration.
   - [X] Reused the existing admin session cookie for both login methods.
 - [X] **Dashboard ACC Red Theme Refresh** (2026-04-29)


### PR DESCRIPTION
## Summary
- Replace dashboard magic-link delivery with direct email + shared password login.
- Create the existing `admin_session` cookie immediately after successful email allowlist and password checks.
- Keep the session lifetime at 24 hours through both JWT expiry and cookie `Max-Age=86400`.
- Keep GitHub allowlist OAuth as a fallback login path.
- Remove the unused admin magic-link email sender.

## Config
- No new environment variable is required.
- Continue using `ADMIN_EMAIL_ALLOWLIST` for authorized ride leader emails.
- Continue using `ADMIN_MAGIC_LINK_PASSWORD` for the shared dashboard password already configured in Vercel.

## Verification
- `PYTHONPYCACHEPREFIX=/tmp/acc-clubhub-pycache python3 -m pytest tests/test_auth_admin_login.py`: 9 passed
- `PYTHONPYCACHEPREFIX=/tmp/acc-clubhub-pycache python3 -m pytest`: 109 passed
- `npm run build`: passed
- `npm run check`: still fails on 14 existing Astro/type-check errors outside this auth change. The login page error introduced in the first PR commit was fixed in `84788d10` and is no longer present in the CI log.

## Notes
- Frontend production routing still relies on `frontend/vercel.json` `/auth/:path*` rewrite to the FastAPI backend.
- Existing local unrelated changes were not included in these commits.