### PR TITLE
i18n: add English and German Eaglet content

### DIFF
--- a/frontend/src/content/events/de/acc-eaglet-basics-2026-08-15.md
+++ b/frontend/src/content/events/de/acc-eaglet-basics-2026-08-15.md
@@ -1,0 +1,111 @@
+---
+slug: acc-eaglet-basics-2026-08-15
+title: Eaglet-Programm 3.0 · Kurs 1｜Grundlagen & Sicherheit
+description: Ausrüstungscheck, Fahrregeln, Bremsen und Schalten, Verkehrssicherheit. 20–30 km lockeres Tempo ab Theresienwiese, Theorie kombiniert mit Praxisfahrt. Mitglieder kostenlos, Studierende 10 €, Nicht-Studierende 15 €.
+location: München · genauer Treffpunkt wird eine Woche vorher bekanntgegeben
+author: ACC Club
+date: 2026-08-15 09:30
+eventType: training-camp
+cover: /images/events/acc-eaglet-basics-2026-08-15/cover.jpg
+displaySections:
+  - hero
+  - upcoming
+heroPriority: 1
+status: published
+ACCOfficialRide: true
+distanceKm: 30
+registrationLink: ''
+---
+
+**Eaglet-Programm 3.0, Kurs 1. Ziel: die richtigen Fahrgewohnheiten aufbauen.**
+
+> Dies ist der erste von drei Kursen. **Jeder Termin muss einzeln angemeldet werden.**
+> Kurs 2｜Gruppenfahrtechnik → [22. August (Samstag)](/de/events/acc-eaglet-groupride-2026-08-22)
+> Kurs 3｜Praxis & Langstrecke → [29. August (Samstag)](/de/events/acc-eaglet-longride-2026-08-29)
+
+Kurs 1 klärt drei Dinge: Was du vor der Abfahrt checken solltest, wie man auf deutschen Straßen sicher fährt, und welche Regeln in der Gruppe gelten.
+
+Keine Vorkenntnisse im Gruppenfahren nötig — genau das lernst du hier.
+
+***
+
+|  |  |
+| --- | --- |
+| **Zeit** | 15. August 2026 (**Samstag**) · **Abfahrt 9:30 Uhr** |
+| **Treffpunkt** | München · genauer Ort wird eine Woche vorher bekanntgegeben |
+| **Distanz / Intensität** | **20–30 km**, entspanntes Tempo, mit Guide während der gesamten Fahrt |
+| **Kursgebühr** | ACC-Mitglieder **kostenlos** · Nicht-Mitglieder (Studierende) **10 €** · Nicht-Mitglieder (sonstige) **15 €** |
+| **Zu beachten** | Helmpflicht; bitte Wasser und Grundverpflegung mitbringen |
+
+> Der genaue Treffpunkt wird eine Woche vor dem Kurs in der WeChat-Gruppe bekanntgegeben. Bei schlechtem Wetter kann der Termin auf Sonntag verschoben werden — wir informieren rechtzeitig.
+
+***
+
+## Kursinhalt
+
+### Teil 1: Vorbereitung vor der Fahrt
+
+- **Persönliche Ausrüstung**: Helm, Brille, Handschuhe, Klickschuhe, Radtrikot
+- **ABC-Check vor der Abfahrt**: Reifendruck, Bremsen, Antrieb, Schnellspanner / Steckachse, Gesamtcheck
+- **Werkzeug für unterwegs**: Ersatzschlauch, Reifenheber, Pumpe / CO₂, Multitool, Kettenschloss
+
+### Teil 2: Deutsche Verkehrsregeln fürs Radfahren
+
+- Radweg-Nutzungspflicht: Wann ein Radweg **verpflichtend** ist (Zeichen 237 / 240 / 241)
+- Fahrradstraße, Fahrrad-Zone, Tempo-30-Zone
+- **Rechts vor links** und Vorfahrtsregeln an Kreuzungen
+- Ampelregeln, die zwei Arten des Linksabbiegens
+- Häufige deutsche Radverkehrszeichen
+
+### Teil 3: Grundlagen der Gruppenfahrt
+
+**Fahrregeln für die Gruppe** — Handzeichen, Zurufe, Einzel- / Doppelreihe, Überholen, Sicherheitsabstand, Kreuzungen sicher passieren.
+
+Die wichtigste Regel: **niemals das Vorderrad überlappen**. Das ist die häufigste einzelne Sturzursache in der Gruppe.
+
+### Teil 4: Grundlegende Radeinstellung
+
+Sattelhöhe, Griffposition, Schaltgrundlagen, sinnvolle Trittfrequenz, richtiges Bremsen.
+
+Im Fokus: **Warum tut das Treten so weh? Warum trittst du oft ins Leere? Warum schaltet es nicht sauber?**
+
+### Teil 5: Praxistraining
+
+Anfahren, Anhalten, Schalten, hohe Trittfrequenz, Notbremsung, Kurvenfahrt, einfaches Windschattenfahren.
+
+***
+
+## Tagesablauf
+
+1. Aufwärmrunden auf der **Theresienwiese**, Handzeichen üben
+2. Weiterfahrt zur **Regatta-Anlage**, dabei praktisch durch eine Tempo-30-Zone (rechts vor links), Fahrrad-Zone, Radweg, kombinierten Rad-/Fußweg und Fahrbahn mit Ampeln — Theorie trifft Praxis
+3. **Kaffeepause**
+4. Weiter zum **Fröttmaninger Müllberg** für eine kleine Steigung, dort Trittfrequenz, Schalten und Bremsen bergauf/bergab üben
+5. Abschluss und Fragerunde, danach lösen wir uns am Müllberg individuell auf
+
+***
+
+## Vorbereitung vor dem Kurs
+
+Die Theorie haben wir bereits als Artikel aufbereitet — nach der Anmeldung einmal durchlesen, dann läuft der Kurstag deutlich entspannter:
+
+- [Vor der Abfahrt: Ausrüstungscheckliste und ABC-Schnellcheck](/de/knowledge/training/pre-ride-check-abc)
+- [Deutsche Verkehrsregeln fürs Radfahren: ein Leitfaden für Einsteiger](/de/knowledge/training/german-cycling-traffic-rules)
+- [Fahrregeln für die Gruppe: Handzeichen, Formation und Sicherheitsabstand](/de/knowledge/training/acc-group-riding-rules)
+- [Grundlegende Radeinstellung: Sattelhöhe, Griffposition und Schaltung](/de/knowledge/training/bike-setup-basics)
+- [Trittfrequenz, Schalten und Bremsen: drei zentrale Fahrtechniken](/de/knowledge/training/cadence-shifting-braking)
+
+***
+
+## Anmeldehinweise
+
+**Bitte melde dich mit deinem echten Namen über das RSVP-Formular unten auf dieser Seite an.** Die Anmeldung über die Website unter echtem Namen sichert euren Versicherungsschutz und hilft uns, Trainer und Gruppen entsprechend der Teilnehmerzahl zu planen. Eine Zusage per Telegram oder WeChat gilt nicht als offizielle Anmeldung.
+
+**Teilnahmevoraussetzungen:**
+
+- Ein funktionstüchtiges Rennrad (oder ein anderes für Straßenfahrten geeignetes Rad)
+- **Helmpflicht**
+- Fähigkeit, mindestens 20 km am Stück zu fahren
+- Keine Vorkenntnisse im Gruppenfahren erforderlich
+
+Sicherheitshinweis: Radfahren birgt inhärente Risiken. Der Kurs vermittelt Sicherheitsregeln systematisch und wird durchgehend von einem Guide begleitet — dennoch liegt es an jedem Teilnehmenden, die eigenen Fähigkeiten realistisch einzuschätzen und für die eigene Sicherheit verantwortlich zu bleiben.

--- a/frontend/src/content/events/de/acc-eaglet-groupride-2026-08-22.md
+++ b/frontend/src/content/events/de/acc-eaglet-groupride-2026-08-22.md
@@ -1,0 +1,105 @@
+---
+slug: acc-eaglet-groupride-2026-08-22
+title: Eaglet-Programm 3.0 · Kurs 2｜Gruppenfahrtechnik
+description: Windschattenfahren, Rotation, Handzeichen, Formation, Effizienz. 40–60 km Gruppentraining mit Berg- und Kurventechnik, Verpflegungsstrategie und Routenplanung. Mitglieder kostenlos, Studierende 10 €, Nicht-Studierende 15 €.
+location: München · genauer Treffpunkt wird eine Woche vorher bekanntgegeben
+author: ACC Club
+date: 2026-08-22 09:30
+eventType: training-camp
+cover: /images/events/acc-eaglet-groupride-2026-08-22/cover.jpg
+displaySections:
+  - hero
+  - upcoming
+heroPriority: 2
+status: published
+ACCOfficialRide: true
+distanceKm: 60
+registrationLink: ''
+---
+
+**Eaglet-Programm 3.0, Kurs 2. Ziel: sicher an einer offiziellen ACC-Gruppenausfahrt teilnehmen können.**
+
+> Dies ist der zweite von drei Kursen. **Jeder Termin muss einzeln angemeldet werden.**
+> Kurs 1｜Grundlagen & Sicherheit → [15. August (Samstag)](/de/events/acc-eaglet-basics-2026-08-15)
+> Kurs 3｜Praxis & Langstrecke → [29. August (Samstag)](/de/events/acc-eaglet-longride-2026-08-29)
+
+Kurs 1 hat dir gezeigt, wie du sicher alleine fährst. Kurs 2 zeigt dir, wie du dich stabil und effizient in einer Gruppe bewegst — Windschattenfahren, Rotation, Handzeichen, Formation.
+
+Kurs 1 vorher zu absolvieren ist empfohlen, gleichwertige Grundkenntnisse reichen aber auch.
+
+***
+
+|  |  |
+| --- | --- |
+| **Zeit** | 22. August 2026 (**Samstag**) · **Abfahrt 9:30 Uhr** |
+| **Treffpunkt** | München · genauer Ort wird eine Woche vorher bekanntgegeben |
+| **Distanz / Intensität** | **40–60 km**, mittleres Tempo, mit Guide während der gesamten Fahrt |
+| **Kursgebühr** | ACC-Mitglieder **kostenlos** · Nicht-Mitglieder (Studierende) **10 €** · Nicht-Mitglieder (sonstige) **15 €** |
+| **Zu beachten** | Helmpflicht; bitte Wasser, Verpflegung und grundlegendes Werkzeug mitbringen |
+
+> Der genaue Treffpunkt wird eine Woche vor dem Kurs in der WeChat-Gruppe bekanntgegeben. Bei schlechtem Wetter kann der Termin auf Sonntag verschoben werden — wir informieren rechtzeitig.
+
+***
+
+## Kursinhalt
+
+### Teil 1: Fahrtechnik im Windschatten
+
+- **Abstand halten**: Einsteiger 1–2 Radlängen, bergab deutlich mehr
+- **Blick nach vorn auf 3–5 Räder** — nicht starr auf das Hinterrad vor dir schauen
+- **Notbremsungen vermeiden**: erst Ausrollen, dann erst bremsen
+- **Rotationstechnik: Pull & Rotate**
+
+### Teil 2: Fortgeschrittene Fahrtechnik
+
+**Bergauf**: Schaltzeitpunkt, Rhythmuskontrolle, Sitz- / Wiegetritt, Tempowahl
+
+**Bergab**: Körperschwerpunkt, Kurvenlinie, Unterlenkerposition, sicheres Bremsen
+
+**Kurven**: Außen-innen-außen-Linie, **nicht in der Kurve scharf bremsen**
+
+### Teil 3: Verpflegung unterwegs
+
+Wie lange kannst du fahren, bevor du essen musst? Wasser, Elektrolyte, Energiegels und -riegel im Vergleich, sowie die drei Phasen **Ride Before / During / After**.
+
+### Teil 4: Routenplanung
+
+Praktischer Umgang mit Garmin / Wahoo / Strava: Navigation, GPX-Import, Höhenmeter einschätzen, Wasserstopps planen.
+
+### Teil 5: Gruppentraining (40–60 km)
+
+Praxisfahrt mit **Rotation, Windschattenfahren, Bergauf-/Bergabfahren, Rhythmuskontrolle**.
+
+***
+
+## Zur Rotation
+
+Rotation ist die Technik, mit der eine Gruppe den Windwiderstand gleichmäßig verteilt. Ein paar wichtige Punkte:
+
+- Nach einer Zeit an der Spitze **weich** zur Seite ausscheren, **weitertreten, nicht abbremsen** — durch Nachlassen der Tretkraft fällst du natürlich zurück
+- Für Einsteigergruppen empfehlen sich 30 Sekunden bis 2 Minuten pro Führungswechsel — nicht übernehmen
+- **Beim ersten Mal musst du nicht rotieren** — bleib in der hinteren Hälfte und sag dem Guide vorher Bescheid
+- Wird es anstrengend, einfach eine Runde aussetzen — das fällt niemandem negativ auf
+
+***
+
+## Vorbereitung vor dem Kurs
+
+- [Fahrregeln für die Gruppe: Handzeichen, Formation und Sicherheitsabstand](/de/knowledge/training/acc-group-riding-rules)
+- [Trittfrequenz, Schalten und Bremsen: drei zentrale Fahrtechniken](/de/knowledge/training/cadence-shifting-braking)
+- [Deutsche Verkehrsregeln fürs Radfahren: ein Leitfaden für Einsteiger](/de/knowledge/training/german-cycling-traffic-rules)
+
+***
+
+## Anmeldehinweise
+
+**Bitte melde dich mit deinem echten Namen über das RSVP-Formular unten auf dieser Seite an.** Die Anmeldung über die Website unter echtem Namen sichert euren Versicherungsschutz und hilft uns, Trainer und Gruppen entsprechend der Teilnehmerzahl zu planen. Eine Zusage per Telegram oder WeChat gilt nicht als offizielle Anmeldung.
+
+**Teilnahmevoraussetzungen:**
+
+- Ein funktionstüchtiges Rennrad
+- **Helmpflicht**
+- Fähigkeit, mindestens 40 km am Stück zu fahren
+- Kurs 1 vorher zu absolvieren ist empfohlen, gleichwertige Grundkenntnisse reichen aber auch
+
+Sicherheitshinweis: Radfahren birgt inhärente Risiken. Der Kurs vermittelt Sicherheitsregeln systematisch und wird durchgehend von einem Guide begleitet — dennoch liegt es an jedem Teilnehmenden, die eigenen Fähigkeiten realistisch einzuschätzen und für die eigene Sicherheit verantwortlich zu bleiben.

--- a/frontend/src/content/events/de/acc-eaglet-longride-2026-08-29.md
+++ b/frontend/src/content/events/de/acc-eaglet-longride-2026-08-29.md
@@ -1,0 +1,102 @@
+---
+slug: acc-eaglet-longride-2026-08-29
+title: Eaglet-Programm 3.0 · Kurs 3｜Praxis & Langstrecke
+description: Langstreckenfahrten, Verpflegungsstrategie, Pacing, echtes Streckentraining. 60–90 km Praxisfahrt mit Fahrradwartung und Ausrüstungstipps, begleitet von erfahrenen ACC-Guides und Pro-Fahrern. Mitglieder kostenlos, Studierende 10 €, Nicht-Studierende 15 €.
+location: München · genauer Treffpunkt wird eine Woche vorher bekanntgegeben
+author: ACC Club
+date: 2026-08-29 09:30
+eventType: training-camp
+cover: /images/events/acc-eaglet-longride-2026-08-29/cover.jpg
+displaySections:
+  - hero
+  - upcoming
+heroPriority: 3
+status: published
+ACCOfficialRide: true
+distanceKm: 90
+registrationLink: ''
+---
+
+**Eaglet-Programm 3.0, Kurs 3. Ziel: Langstreckenfahrten selbstständig bewältigen können.**
+
+> Dies ist der dritte von drei Kursen. **Jeder Termin muss einzeln angemeldet werden.**
+> Kurs 1｜Grundlagen & Sicherheit → [15. August (Samstag)](/de/events/acc-eaglet-basics-2026-08-15)
+> Kurs 2｜Gruppenfahrtechnik → [22. August (Samstag)](/de/events/acc-eaglet-groupride-2026-08-22)
+
+Im letzten Kurs bringen wir alles aus den ersten beiden Terminen auf eine echte Strecke: lange Anstiege, lange Abfahrten, Verpflegungsstopps, Pacing. **Dieses Mal haben wir zusätzlich erfahrene ACC-Fahrer und Pro-Fahrer eingeladen, die ihre Erfahrung teilen.**
+
+Kurs 1 und 2 vorher zu absolvieren ist empfohlen, gleichwertige Gruppenfahrerfahrung reicht aber auch.
+
+***
+
+|  |  |
+| --- | --- |
+| **Zeit** | 29. August 2026 (**Samstag**) · **Abfahrt 9:30 Uhr** |
+| **Treffpunkt** | München · genauer Ort wird eine Woche vorher bekanntgegeben |
+| **Distanz / Intensität** | **60–90 km**, mit langem Anstieg und langer Abfahrt, mit Guide während der gesamten Fahrt |
+| **Kursgebühr** | ACC-Mitglieder **kostenlos** · Nicht-Mitglieder (Studierende) **10 €** · Nicht-Mitglieder (sonstige) **15 €** |
+| **Zu beachten** | Helmpflicht; bitte ausreichend Wasser und Verpflegung, Ersatzschlauch und Werkzeug mitbringen |
+
+> Der genaue Treffpunkt wird eine Woche vor dem Kurs in der WeChat-Gruppe bekanntgegeben. Bei schlechtem Wetter kann der Termin auf Sonntag verschoben werden — wir informieren rechtzeitig.
+
+***
+
+## Kursinhalt
+
+### Teil 1: Erfahrungen aus dem Langstreckenfahren
+
+Von erfahrenen ACC-Guides und Pro-Fahrern:
+
+- **Vorbereitung auf 100 km+**: Grundlagenausdauer, Streckenrecherche, Zeitplanung
+- **Pacing**: nicht zu schnell starten und in der zweiten Hälfte einbrechen
+- **Verpflegungsstrategie**: Rhythmus und Stopps bei langen Distanzen
+- **Wettereinschätzung**: worauf du vor der Abfahrt achtest und wie du unterwegs reagierst
+- **Bike Packing**
+
+### Teil 2: Fahrradwartung (praktisch)
+
+**Grundlagen für alle**: Kette reinigen, ölen, Verschleiß prüfen
+
+**Grundreparaturen**: Schlauchwechsel, Feinjustierung des Schaltwerks, Justierung der elektronischen Schaltung, Prinzip der Anschlagschrauben (nur zum Verständnis), Bremsencheck
+
+### Teil 3: Ausrüstungstipps
+
+Fahrradcomputer, Leistungsmesser, Beleuchtung, **Radar**, Bike-Packing-Ausrüstung, Regenausrüstung, Winterausrüstung.
+
+### Teil 4: Praxisfahrt (60–90 km)
+
+Mit **Gruppenfahren, langem Anstieg, langer Abfahrt, Verpflegungsstopps**, jede*r Teilnehmende kann optional **selbst die Führung übernehmen**.
+
+### Teil 5: Abschluss
+
+Kursrückblick, Fragerunde, Erfahrungsaustausch, Empfehlungen für die weitere Trainingsplanung.
+
+***
+
+## Nach Abschluss des Kurses
+
+- Erhalt des **ACC-Eaglet-Programm-Zertifikats**
+- Empfehlung zur Teilnahme an **offiziellen ACC-Gruppenausfahrten**
+
+***
+
+## Vorbereitung vor dem Kurs
+
+- [Trittfrequenz, Schalten und Bremsen: drei zentrale Fahrtechniken](/de/knowledge/training/cadence-shifting-braking)
+- [Grundlegende Radeinstellung: Sattelhöhe, Griffposition und Schaltung](/de/knowledge/training/bike-setup-basics)
+- [Vor der Abfahrt: Ausrüstungscheckliste und ABC-Schnellcheck](/de/knowledge/training/pre-ride-check-abc)
+
+***
+
+## Anmeldehinweise
+
+**Bitte melde dich mit deinem echten Namen über das RSVP-Formular unten auf dieser Seite an.** Die Anmeldung über die Website unter echtem Namen sichert euren Versicherungsschutz und hilft uns, Trainer und Gruppen entsprechend der Teilnehmerzahl zu planen. Eine Zusage per Telegram oder WeChat gilt nicht als offizielle Anmeldung.
+
+**Teilnahmevoraussetzungen:**
+
+- Ein funktionstüchtiges Rennrad, **bitte vor der Abfahrt selbst den ABC-Check durchführen**
+- **Helmpflicht**
+- Fähigkeit, mindestens 60 km am Stück zu fahren
+- Kurs 1 und 2 vorher zu absolvieren ist empfohlen, gleichwertige Gruppenfahrerfahrung reicht aber auch
+
+Sicherheitshinweis: Radfahren birgt inhärente Risiken. Der Kurs vermittelt Sicherheitsregeln systematisch und wird durchgehend von einem Guide begleitet — dennoch liegt es an jedem Teilnehmenden, die eigenen Fähigkeiten realistisch einzuschätzen und für die eigene Sicherheit verantwortlich zu bleiben.

--- a/frontend/src/content/events/en/acc-eaglet-basics-2026-08-15.md
+++ b/frontend/src/content/events/en/acc-eaglet-basics-2026-08-15.md
@@ -1,0 +1,111 @@
+---
+slug: acc-eaglet-basics-2026-08-15
+title: Eaglet Program 3.0 · Session 1｜Basics & Safety
+description: Gear checks, riding etiquette, braking and shifting, road safety. 20–30 km easy pace from Theresienwiese, theory combined with a practice ride. Free for members, 10 € for students, 15 € for non-students.
+location: Munich · exact meeting point announced one week ahead
+author: ACC Club
+date: 2026-08-15 09:30
+eventType: training-camp
+cover: /images/events/acc-eaglet-basics-2026-08-15/cover.jpg
+displaySections:
+  - hero
+  - upcoming
+heroPriority: 1
+status: published
+ACCOfficialRide: true
+distanceKm: 30
+registrationLink: ''
+---
+
+**Eaglet Program 3.0, Session 1. Goal: build the right riding habits.**
+
+> This is the first of three sessions. **Each session needs its own registration.**
+> Session 2｜Group Riding Skills → [August 22 (Saturday)](/en/events/acc-eaglet-groupride-2026-08-22)
+> Session 3｜Real-World Riding → [August 29 (Saturday)](/en/events/acc-eaglet-longride-2026-08-29)
+
+Session 1 covers three things: what to check before you leave the house, how to ride safely on German roads, and what the rules are once you're riding with a group.
+
+No group-riding experience needed — that's exactly what this session teaches.
+
+***
+
+|  |  |
+| --- | --- |
+| **Time** | August 15, 2026 (**Saturday**) · **departure 9:30 AM** |
+| **Meeting point** | Munich · exact location announced one week ahead |
+| **Distance / Intensity** | **20–30 km**, easy pace, led by a guide throughout |
+| **Course fee** | ACC members **free** · non-member students **10 €** · non-member non-students **15 €** |
+| **Notes** | Helmet required; please bring water and basic snacks |
+
+> The exact meeting point will be posted in the WeChat group one week before the session. In case of bad weather, the session may move to Sunday — we'll notify you in time.
+
+***
+
+## What's covered
+
+### Part 1: Pre-ride preparation
+
+- **Personal gear**: helmet, glasses, gloves, cleats, riding kit
+- **ABC pre-ride check**: tire pressure, brakes, drivetrain, quick release / thru axle, full bike check
+- **Tools to carry**: spare tube, tire levers, pump / CO₂, multi-tool, quick chain link
+
+### Part 2: German traffic rules for cyclists
+
+- Bike lane right-of-way: when a bike lane is **mandatory** (signs 237 / 240 / 241)
+- Fahrradstraße (bike streets), Fahrrad-Zone, 30 km/h zones
+- **Right-before-left** and priority at intersections
+- Traffic light rules, the two ways to turn left
+- Common German cycling road signs
+
+### Part 3: Group riding basics
+
+**Group riding etiquette** — hand signals, verbal calls, single / double file, overtaking, safe following distance, how to clear intersections as a group.
+
+The single most important rule: **never overlap your front wheel with the rider ahead**. It's the leading single cause of crashes in group rides.
+
+### Part 4: Bike setup basics
+
+Saddle height, hand positions, basic shifting, sensible cadence, correct braking.
+
+The three questions we'll answer: **Why does pedaling feel so hard? Why do you keep pedaling into thin air? Why does shifting feel rough?**
+
+### Part 5: Hands-on practice
+
+Starting off, stopping, shifting, high cadence, emergency braking, cornering, basic drafting.
+
+***
+
+## Session schedule
+
+1. Warm-up laps at **Theresienwiese**, practicing hand signals
+2. Ride to **Regatta-Anlage**, passing through a real 30 km/h zone (right-before-left), a Fahrrad-Zone, a bike lane, a shared bike/pedestrian path, and open road with traffic lights — theory meets practice
+3. **Coffee break (Kaffeepause)**
+4. On to **Fröttmaninger Müllberg** for a short climb, practicing cadence, shifting, and braking on the way up and down
+5. Wrap-up and Q&A, then everyone disperses independently at Müllberg
+
+***
+
+## Pre-session reading
+
+We've written up the theory as articles — read through them after registering and the session will feel much easier:
+
+- [Pre-Ride Checks: Gear List and the ABC Quick Check](/en/knowledge/training/pre-ride-check-abc)
+- [German Traffic Rules for Cyclists: A Beginner's Guide](/en/knowledge/training/german-cycling-traffic-rules)
+- [Group Riding Etiquette: Hand Signals, Formation, and Following Distance](/en/knowledge/training/acc-group-riding-rules)
+- [Bike Setup Basics: Saddle Height, Hand Position, and Shifting](/en/knowledge/training/bike-setup-basics)
+- [Cadence, Shifting, and Braking: Three Core Riding Skills](/en/knowledge/training/cadence-shifting-braking)
+
+***
+
+## Registration notes
+
+**Please register with your real name via the RSVP form at the bottom of this page.** Real-name registration through the website protects your insurance coverage and helps us plan coaching and group sizes. Saying you'll join on Telegram or WeChat does not count as registration.
+
+**To join, you'll need:**
+
+- A road bike in working order (or another bike suitable for road riding)
+- **Helmet required**
+- The ability to ride 20 km continuously
+- No group-riding experience needed
+
+Safety note: cycling carries inherent risk. The session covers safety practices systematically and is led by a guide throughout, but every participant is responsible for judging their own ability and staying safe.

--- a/frontend/src/content/events/en/acc-eaglet-groupride-2026-08-22.md
+++ b/frontend/src/content/events/en/acc-eaglet-groupride-2026-08-22.md
@@ -1,0 +1,105 @@
+---
+slug: acc-eaglet-groupride-2026-08-22
+title: Eaglet Program 3.0 · Session 2｜Group Riding Skills
+description: Drafting, rotation, hand signals, formation, efficiency. 40–60 km group training with climbing and cornering technique, fueling strategy, and route planning. Free for members, 10 € for students, 15 € for non-students.
+location: Munich · exact meeting point announced one week ahead
+author: ACC Club
+date: 2026-08-22 09:30
+eventType: training-camp
+cover: /images/events/acc-eaglet-groupride-2026-08-22/cover.jpg
+displaySections:
+  - hero
+  - upcoming
+heroPriority: 2
+status: published
+ACCOfficialRide: true
+distanceKm: 60
+registrationLink: ''
+---
+
+**Eaglet Program 3.0, Session 2. Goal: be ready to safely join an official ACC group ride.**
+
+> This is the second of three sessions. **Each session needs its own registration.**
+> Session 1｜Basics & Safety → [August 15 (Saturday)](/en/events/acc-eaglet-basics-2026-08-15)
+> Session 3｜Real-World Riding → [August 29 (Saturday)](/en/events/acc-eaglet-longride-2026-08-29)
+
+Session 1 taught you how to ride safely on your own. Session 2 teaches you how to ride steadily and efficiently with a group — drafting, rotation, hand signals, formation.
+
+Completing Session 1 first is recommended, but equivalent basic knowledge also works.
+
+***
+
+|  |  |
+| --- | --- |
+| **Time** | August 22, 2026 (**Saturday**) · **departure 9:30 AM** |
+| **Meeting point** | Munich · exact location announced one week ahead |
+| **Distance / Intensity** | **40–60 km**, moderate pace, led by a guide throughout |
+| **Course fee** | ACC members **free** · non-member students **10 €** · non-member non-students **15 €** |
+| **Notes** | Helmet required; please bring water, snacks, and basic tools |
+
+> The exact meeting point will be posted in the WeChat group one week before the session. In case of bad weather, the session may move to Sunday — we'll notify you in time.
+
+***
+
+## What's covered
+
+### Part 1: Drafting technique
+
+- **Keeping distance**: 1–2 bike lengths for beginners, noticeably more downhill
+- **Looking 3–5 riders ahead** — don't fixate on the wheel right in front of you
+- **Avoiding hard braking**: coast off first, brake only if you have to
+- **Rotation technique: Pull & Rotate**
+
+### Part 2: Advanced riding technique
+
+**Climbing**: when to shift, pacing, seated vs. standing, effort management
+
+**Descending**: body position, cornering line, using the drops, safe braking
+
+**Cornering**: outside-inside-outside line, **never brake hard mid-corner**
+
+### Part 3: Fueling on the ride
+
+How long can you go before you need to eat? Water, electrolytes, gels, and bars compared, plus the three-phase **Ride Before / During / After** approach.
+
+### Part 4: Route planning
+
+Hands-on with Garmin / Wahoo / Strava: navigation, GPX import, reading elevation gain, planning water stops.
+
+### Part 5: Group training (40–60 km)
+
+A real ride practicing **rotation, drafting, climbing, descending, and pacing**.
+
+***
+
+## About rotation
+
+Rotation is how a group shares wind resistance evenly. A few key points:
+
+- After a turn at the front, pull off **smoothly** to the side, **keep pedaling — don't slow down** — let easing off naturally drop you back
+- For beginner groups, 30 seconds to 2 minutes per pull is plenty — don't overdo it
+- **You don't have to rotate the first time you join.** Sit in the back half and let the guide know beforehand
+- If it's getting hard, just sit out a rotation — nobody thinks less of you for it
+
+***
+
+## Pre-session reading
+
+- [Group Riding Etiquette: Hand Signals, Formation, and Following Distance](/en/knowledge/training/acc-group-riding-rules)
+- [Cadence, Shifting, and Braking: Three Core Riding Skills](/en/knowledge/training/cadence-shifting-braking)
+- [German Traffic Rules for Cyclists: A Beginner's Guide](/en/knowledge/training/german-cycling-traffic-rules)
+
+***
+
+## Registration notes
+
+**Please register with your real name via the RSVP form at the bottom of this page.** Real-name registration through the website protects your insurance coverage and helps us plan coaching and group sizes. Saying you'll join on Telegram or WeChat does not count as registration.
+
+**To join, you'll need:**
+
+- A road bike in working order
+- **Helmet required**
+- The ability to ride 40 km continuously
+- Completing Session 1 first is recommended, but equivalent basic knowledge also works
+
+Safety note: cycling carries inherent risk. The session covers safety practices systematically and is led by a guide throughout, but every participant is responsible for judging their own ability and staying safe.

--- a/frontend/src/content/events/en/acc-eaglet-longride-2026-08-29.md
+++ b/frontend/src/content/events/en/acc-eaglet-longride-2026-08-29.md
@@ -1,0 +1,102 @@
+---
+slug: acc-eaglet-longride-2026-08-29
+title: Eaglet Program 3.0 · Session 3｜Real-World Riding
+description: Long-distance riding, fueling strategy, pacing, real-route practice. 60–90 km practice ride with hands-on bike maintenance and a gear session, joined by experienced ACC guides and pro riders. Free for members, 10 € for students, 15 € for non-students.
+location: Munich · exact meeting point announced one week ahead
+author: ACC Club
+date: 2026-08-29 09:30
+eventType: training-camp
+cover: /images/events/acc-eaglet-longride-2026-08-29/cover.jpg
+displaySections:
+  - hero
+  - upcoming
+heroPriority: 3
+status: published
+ACCOfficialRide: true
+distanceKm: 90
+registrationLink: ''
+---
+
+**Eaglet Program 3.0, Session 3. Goal: ride long distances independently.**
+
+> This is the third of three sessions. **Each session needs its own registration.**
+> Session 1｜Basics & Safety → [August 15 (Saturday)](/en/events/acc-eaglet-basics-2026-08-15)
+> Session 2｜Group Riding Skills → [August 22 (Saturday)](/en/events/acc-eaglet-groupride-2026-08-22)
+
+The final session takes everything from the first two and puts it on a real route: long climbs, long descents, fuel stops, pacing. **We've also invited a few experienced ACC riders and pros to share what they've learned.**
+
+Completing Sessions 1 and 2 first is recommended, but equivalent group-riding experience also works.
+
+***
+
+|  |  |
+| --- | --- |
+| **Time** | August 29, 2026 (**Saturday**) · **departure 9:30 AM** |
+| **Meeting point** | Munich · exact location announced one week ahead |
+| **Distance / Intensity** | **60–90 km**, with a long climb and a long descent, led by a guide throughout |
+| **Course fee** | ACC members **free** · non-member students **10 €** · non-member non-students **15 €** |
+| **Notes** | Helmet required; please bring plenty of water and snacks, a spare tube, and basic tools |
+
+> The exact meeting point will be posted in the WeChat group one week before the session. In case of bad weather, the session may move to Sunday — we'll notify you in time.
+
+***
+
+## What's covered
+
+### Part 1: Long-distance riding experience
+
+Shared by experienced ACC guides and pro riders:
+
+- **Preparing for 100 km+**: base fitness, route research, time budgeting
+- **Pacing**: avoiding a fast start that leaves you cooked in the second half
+- **Fueling strategy**: rhythm and stop planning for long distances
+- **Reading the weather**: what to check before you leave and how to adapt on the road
+- **Bike packing**
+
+### Part 2: Bike maintenance (hands-on)
+
+**Everyone should know**: cleaning and lubing the chain, checking for wear
+
+**Basic repairs**: tube replacement, rear derailleur fine-tuning, electronic shifting adjustment, how limit screws work (for understanding, not adjustment), brake checks
+
+### Part 3: Gear session
+
+Bike computers, power meters, lights, **radar units**, bike-packing gear, rain gear, winter gear.
+
+### Part 4: Practice ride (60–90 km)
+
+Includes **group riding, a long climb, a long descent, and fuel stops**, with each participant optionally getting a turn **leading the group**.
+
+### Part 5: Wrap-up
+
+Course recap, Q&A, shared experiences, recommendations for continuing to train.
+
+***
+
+## After completing the program
+
+- Receive your **ACC Eaglet Program completion**
+- Recommended for joining **official ACC group rides**
+
+***
+
+## Pre-session reading
+
+- [Cadence, Shifting, and Braking: Three Core Riding Skills](/en/knowledge/training/cadence-shifting-braking)
+- [Bike Setup Basics: Saddle Height, Hand Position, and Shifting](/en/knowledge/training/bike-setup-basics)
+- [Pre-Ride Checks: Gear List and the ABC Quick Check](/en/knowledge/training/pre-ride-check-abc)
+
+***
+
+## Registration notes
+
+**Please register with your real name via the RSVP form at the bottom of this page.** Real-name registration through the website protects your insurance coverage and helps us plan coaching and group sizes. Saying you'll join on Telegram or WeChat does not count as registration.
+
+**To join, you'll need:**
+
+- A road bike in working order — **please run your own ABC check before the ride**
+- **Helmet required**
+- The ability to ride 60 km continuously
+- Completing Sessions 1 and 2 first is recommended, but equivalent group-riding experience also works
+
+Safety note: cycling carries inherent risk. The session covers safety practices systematically and is led by a guide throughout, but every participant is responsible for judging their own ability and staying safe.

--- a/frontend/src/content/events/zh/acc-eaglet-basics-2026-08-15.md
+++ b/frontend/src/content/events/zh/acc-eaglet-basics-2026-08-15.md
@@ -59,7 +59,7 @@ registrationLink: ''
 
 ### 第三部分：团骑基础
 
-**ACC 团骑规范**——手势、口令、单列 / 双列、超车、安全距离、如何通过路口。
+**团骑规范**——手势、口令、单列 / 双列、超车、安全距离、如何通过路口。
 
 其中最重要的一条：**严禁叠轮**。这是团骑摔车最主要的单一原因。
 
@@ -91,7 +91,7 @@ registrationLink: ''
 
 - [出发前准备：装备清单与 ABC 快速检查](/zh/knowledge/training/pre-ride-check-abc)
 - [德国骑行交规与路权：新手必读](/zh/knowledge/training/german-cycling-traffic-rules)
-- [ACC 团骑规范：手势、队形与安全距离](/zh/knowledge/training/acc-group-riding-rules)
+- [团骑规范：手势、队形与安全距离](/zh/knowledge/training/acc-group-riding-rules)
 - [车辆基础设置：座高、握姿与变速调整](/zh/knowledge/training/bike-setup-basics)
 - [踏频、换挡与刹车：三项核心骑行技术](/zh/knowledge/training/cadence-shifting-braking)
 

--- a/frontend/src/content/events/zh/acc-eaglet-groupride-2026-08-22.md
+++ b/frontend/src/content/events/zh/acc-eaglet-groupride-2026-08-22.md
@@ -81,13 +81,11 @@ Garmin / Wahoo / Strava 的实际使用：导航、GPX 导入、爬升判断、�
 - **第一次参加可以完全不轮车**，跟在中后段，提前告诉领骑
 - 感觉吃力就跳过一轮。把队伍拉爆才是问题
 
-> 轮换方向由当日领骑在出发前统一宣布，**以现场宣布为准**。
-
 ***
 
 ## 课前预习
 
-- [ACC 团骑规范：手势、队形与安全距离](/zh/knowledge/training/acc-group-riding-rules)
+- [团骑规范：手势、队形与安全距离](/zh/knowledge/training/acc-group-riding-rules)
 - [踏频、换挡与刹车：三项核心骑行技术](/zh/knowledge/training/cadence-shifting-braking)
 - [德国骑行交规与路权：新手必读](/zh/knowledge/training/german-cycling-traffic-rules)
 

--- a/frontend/src/content/knowledge/training/de/acc-group-riding-rules.md
+++ b/frontend/src/content/knowledge/training/de/acc-group-riding-rules.md
@@ -1,0 +1,141 @@
+---
+slug: acc-group-riding-rules
+category: safety
+title: 'Fahrregeln für die Gruppe: Handzeichen, Formation und Sicherheitsabstand'
+description: 'Beim Gruppenfahren geht es nicht darum, schnell zu sein, sondern darum, dass jede Bewegung für die anderen vorhersehbar bleibt. Handzeichen und Zurufe, Formationsregeln, Sicherheitsabstand, Rotation — und die wichtigste Regel überhaupt: niemals das Vorderrad überlappen.'
+author: ACC Club
+date: 2026-08-03
+featured: true
+tags:
+  - Sicherheit
+  - Gruppenfahrt
+  - Eaglet-Programm
+cover: /images/media/adventure/rad-race-120-2025/gallery/2026-group-turn.jpg
+---
+
+Wenn du alleine fährst, bist du nur dir selbst verantwortlich. In der Gruppe hängt die Sicherheit aller hinter dir davon ab, ob deine Bewegungen **vorhersehbar** sind.
+
+Das ist das zentrale Prinzip beim Gruppenfahren, aus dem sich alle anderen Regeln ableiten lassen:
+
+> **Bleib vorhersehbar. Mach keine Bewegung, auf die die Person hinter dir nicht rechtzeitig reagieren kann.**
+
+## 1. Absolute Grenzen
+
+Bei den folgenden Punkten gibt es keine Ausnahme. Viele Gruppen haben dabei null Toleranz — Verstöße werden sofort angesprochen, bei Wiederholung fliegst du aus der Gruppe:
+
+### 1. Niemals das Vorderrad überlappen
+
+**Überlappen** bedeutet, dass sich dein Vorderrad und das Hinterrad der Person vor dir längs überschneiden. Das ist die häufigste einzelne Sturzursache beim Gruppenfahren.
+
+Das Prinzip ist einfach: Weicht die Person vor dir aus irgendeinem Grund seitlich um ein paar Dutzend Zentimeter aus (Schlagloch, Ausweichen, normales Pendeln), triffst du direkt seitlich ihr Hinterrad. **Ein Vorderrad, das seitlich getroffen wird, verliert sofort das Gleichgewicht** — kaum zu retten, und meist stürzt du zur Innenseite der Gruppe, wodurch du oft weitere Fahrer*innen mit reißt.
+
+Die Person vor dir bemerkt das **überhaupt nicht und kann auch nichts dagegen tun**, weil sie dich nicht sehen kann. **Überlappungen zu vermeiden liegt zu 100 % in der Verantwortung der Person dahinter.**
+
+### 2. Keine Notbremsungen
+
+Eine scharfe Bremsung in der Gruppe löst eine Kettenreaktion aus. Musst du das Tempo reduzieren:
+
+- Zuerst **ausrollen** ohne zu treten, oder dich leicht aufrichten für mehr Luftwiderstand
+- Musst du bremsen, dann **dosiert und weich**, dabei nach hinten „Langsam" rufen
+- Nur in echten Notfällen voll bremsen
+
+Besonders für die Führung an der Spitze gilt: **keine Notbremsungen, während du die Gruppe anführst.** Immer vorausschauen und rechtzeitig verzögern.
+
+### 3. Überholen immer von links
+
+Von rechts zu überholen ist ein Tabu — rechts ist der tote Winkel der Person hinter dir und auch die Seite von Bordstein und Fußgängern.
+
+Nach dem Überholen **nicht sofort wieder einscheren.** Erst sicherstellen, dass du wirklich vorbei bist (im Augenwinkel siehst du die überholte Person hinter dir), dann sanft wieder einordnen.
+
+### 4. Vor dem Spurwechsel oder Einordnen immer über die Schulter schauen
+
+Rückspiegel und Augenwinkel ersetzen keinen **Schulterblick.** Zusammen mit dem Handzeichen.
+
+## 2. Handzeichen und Zurufe
+
+In der Gruppe werden Informationen über Handzeichen und Zurufe weitergegeben. **Jedes Signal muss von Person zu Person nach hinten weitergereicht werden** — wer ganz hinten fährt, braucht diese Information am meisten und sieht die Straße am wenigsten.
+
+### Gängige Handzeichen
+
+| Signal | Bewegung | Bedeutung |
+| --- | --- | --- |
+| **Anhalten** | Handfläche über die Schulter heben (Finger gespreizt) | Vorne muss angehalten werden |
+| **Verlangsamen** | Handfläche nach unten, leicht auf-ab bewegen | Vorne muss das Tempo reduziert werden |
+| **Schlagloch / Hindernis** | Finger nach unten zeigend, auf die betroffene Seite | Loch, Kanaldeckel oder Schotter auf dieser Straßenseite |
+| **Splitt / Sand** | Hand seitlich, Finger spreizen und leicht schütteln | Loser Untergrund, Grip beachten |
+| **Links / rechts abbiegen** | Arm auf der entsprechenden Seite waagerecht ausstrecken | Abbiegen steht bevor |
+| **Ausweichen / auf Einzelreihe wechseln** | Hand hinter dem Rücken in die Richtung zeigen, in die sich die Gruppe bewegen soll | Formation muss enger werden |
+| **Fahrzeug / Fußgänger voraus** | Hand hinter dem Rücken nach innen wedeln | Hindernis auf dieser Seite, näher zusammenrücken |
+
+### Gängige Zurufe
+
+Handzeichen werden oft von Körpern in der Gruppe verdeckt, deshalb müssen wichtige Informationen **gleichzeitig laut gerufen werden:**
+
+„**Halt!**" „**Langsam!**" „**Loch!**" „**Auto hinten!**" (Fahrzeug von hinten) „**Auto vorne!**" (Fahrzeug von vorne oder Gegenverkehr) „**Einzeln!**" (auf Einzelreihe wechseln)
+
+## 3. Formation
+
+**Einzelreihe** ist die Standardformation, geeignet für enge Straßen, viel Verkehr, schlechte Sicht, Anstiege, Abfahrten und Kreuzungen.
+
+**Doppelreihe** eignet sich für breite Straßen, wenig Verkehr und ruhiges Tempo auf der Ebene. Die rechtlichen Voraussetzungen findest du in [Deutsche Verkehrsregeln fürs Radfahren](/de/knowledge/training/german-cycling-traffic-rules):
+
+- **Ab 16 Personen** kann die Gruppe einen geschlossenen Verband nach §27 StVO bilden und legal zu zweit nebeneinander fahren
+- **Bei 15 oder weniger Personen** gilt §2 Abs. 4: nebeneinander nur, wenn niemand behindert wird
+
+In der Doppelreihe sollten die beiden nebeneinander fahrenden Personen **auf gleicher Höhe bleiben**, Schulter an Schulter, nicht versetzt hintereinander — versetzte Positionen schränken den Platz für die dahinterfahrenden Personen ein.
+
+### Kreuzungen passieren
+
+- **Gemeinsam durchfahren**, die Gruppe darf nicht zerrissen werden. Ist das nicht möglich, sollte die vordere Hälfte an einer sicheren Stelle anhalten und warten
+- Vor der Kreuzung proaktiv in die **Einzelreihe** wechseln, danach wieder auflösen
+- **Jede Person muss die Kreuzungssituation selbst einschätzen** und nicht blind der vorausfahrenden Person folgen. Nur weil die Person vor dir durchkommt, heißt das nicht, dass du es auch schaffst — besonders bei Gelblicht
+
+## 4. Sicherheitsabstand
+
+### Wie viel Abstand
+
+| Situation | Abstand |
+| --- | --- |
+| Einsteiger / gemischte Gruppe | 1–2 Radlängen (ca. 2–4 m) |
+| Geübte Gruppe auf der Ebene | Halbes bis ganzes Rad |
+| **Bergab** | **Deutlich mehr, 2–3 Radlängen** |
+| Nasse Fahrbahn | Zusätzlich zum jeweiligen Ausgangswert verdoppeln |
+
+### Blick nach vorn
+
+Der häufigste Fehler bei Einsteigern ist der **starre Blick auf das Hinterrad der Person vor sich.** So kannst du auf deren Bewegungen nur reagieren, und diese Reaktion kommt zwangsläufig zu spät.
+
+Richtig ist: **den Blick über die Person vor dir hinweg auf die nächsten 3–5 Räder richten**, den Abstand zur direkt vorausfahrenden Person über das periphere Sehen halten. So siehst du Straßensituationen fast zeitgleich mit den Personen vorne, statt dass die Information erst Stück für Stück nach hinten durchgereicht wird.
+
+## 5. Rotation
+
+Rotation ist die Technik, mit der eine Gruppe den Windwiderstand gleichmäßig verteilt. Nach einer Zeit an der Spitze fällt man zurück und die nächste Person übernimmt.
+
+### Grundablauf
+
+1. Die Führung übernimmt für eine Strecke (bei Einsteigergruppen 30 Sekunden bis 2 Minuten — nicht übertreiben)
+2. Nach hinten anzeigen (Ellbogen ausstellen oder rufen), dann **weich** seitlich ausscheren
+3. **Weitertreten, nicht abbremsen** — durch Nachlassen der Tretkraft fällt man von selbst zurück. Abruptes Bremsen führt zu Auffahrunfällen
+4. An der Seite der Gruppe nach hinten fallen, zur Rückseite blicken und dann einordnen
+
+### Rotationsrichtung
+
+Die Rotationsrichtung ist nicht fest vorgegeben, sondern hängt vom **Wind** ab: **die windabgewandte Seite ist die Rückfallseite.** So bekommt die zurückfallende Person mehr Windwiderstand und fällt natürlicher zurück, während die vorwärts fahrende Reihe im Windschatten bleibt.
+
+Ohne Wind oder bei unklarer Windrichtung sind beide Richtungen gebräuchlich, es gibt kein absolutes Richtig oder Falsch.
+
+> **Entscheidend ist, dass die ganze Gruppe dieselbe Richtung fährt.** Vor der Abfahrt kurz klären — fahren zwei Personen in entgegengesetzte Richtungen, prallen sie direkt aufeinander, das ist sehr gefährlich.
+
+### Hinweise für Einsteiger*innen
+
+- Beim ersten Mal in der Gruppe **musst du gar nicht rotieren.** Bleib im hinteren Mittelfeld und sag vorher Bescheid
+- Bei der Rotation **nicht beschleunigen.** Viele Einsteiger*innen treten unbewusst stärker, sobald sie an der Spitze sind, wodurch die Gruppe auseinandergerissen wird
+- Wird es anstrengend, **einfach eine Runde aussetzen**, nach hinten anzeigen und andere vorbeilassen. Das fällt niemandem negativ auf — die Gruppe zu überfordern ist das eigentliche Problem
+
+---
+
+## Weiterlesen
+
+- Vor der Abfahrt → [Ausrüstungscheckliste und ABC-Schnellcheck](/de/knowledge/training/pre-ride-check-abc)
+- Rechtliche Grundlagen → [Deutsche Verkehrsregeln fürs Radfahren](/de/knowledge/training/german-cycling-traffic-rules)
+- Fahrtechnik → [Trittfrequenz, Schalten und Bremsen: drei zentrale Fahrtechniken](/de/knowledge/training/cadence-shifting-braking)

--- a/frontend/src/content/knowledge/training/de/bike-setup-basics.md
+++ b/frontend/src/content/knowledge/training/de/bike-setup-basics.md
@@ -1,0 +1,144 @@
+---
+slug: bike-setup-basics
+category: skills
+title: 'Grundlegende Radeinstellung: Sattelhöhe, Griffposition und Schaltung'
+description: 'Warum tut das Treten so weh, warum schmerzt das Knie, warum schaltet es nicht sauber — bei den meisten Einsteiger-Beschwerden liegt die Ursache nicht in der Fitness, sondern in der Radeinstellung. Der vollständige Leitfaden zu Sattelhöhe, Sitzposition, den drei Griffpositionen und der Schaltungsfeinjustierung.'
+author: ACC Club
+date: 2026-08-02
+tags:
+  - Radeinstellung
+  - Bike Fit
+  - Eaglet-Programm
+cover: /images/shared/stock/bike-fitting.jpg
+---
+
+Die drei häufigsten Fragen von Einsteiger*innen — „Warum tut das Treten so weh", „Warum schmerzt das Knie", „Warum schaltet es nie sauber" — haben meistens nichts mit der Fitness zu tun, sondern mit der Radeinstellung.
+
+Dieser Artikel deckt die Grundeinstellungen ab, die du selbst vornehmen kannst. **Für eine tiefergehende Anpassung der Sitzposition (Bike Fit) empfiehlt sich eine Fachperson**, besonders wenn bereits anhaltende Schmerzen auftreten.
+
+## 1. Sattelhöhe
+
+Die Sattelhöhe hat den größten Einfluss und wird am häufigsten falsch eingestellt. **Zu hoch** führt zum seitlichen Pendeln des Beckens beim Treten sowie zu Zerrungen an der Rückseite des Knies und der Beinbeugerkette. **Zu niedrig** führt zu übermäßiger Belastung der Knievorderseite und einer deutlich reduzierten Kraftübertragung.
+
+### Methode 1: Fersenmethode (schneller Einstieg)
+
+Auf den Sattel setzen (jemand sollte das Rad festhalten oder du lehnst dich an eine Wand), **das Becken waagerecht halten**, die Kurbel in die tiefste Position drehen (6-Uhr-Position), mit der **Ferse** auf dem Pedal stehen.
+
+Das Knie sollte dabei **gerade vollständig durchgestreckt** sein, ohne dass sich das Becken zu dieser Seite neigt. Das ist eine sinnvolle Ausgangs-Sattelhöhe.
+
+Vorteil: schnell. Nachteil: berücksichtigt nicht das individuelle Verhältnis von Ober- zu Unterschenkel.
+
+### Methode 2: Schrittlängen-Formel (LeMond-Methode)
+
+**Sattelhöhe = Schrittlänge × 0,883**
+
+- **Schrittlänge (Inseam) messen**: barfuß mit dem Rücken an der Wand stehen, Füße etwa 15 cm auseinander, ein Buch zwischen die Beine klemmen und nach oben drücken bis zum spürbaren Widerstand (simuliert den Sattelkontakt), den vertikalen Abstand vom Buchrücken zum Boden messen
+- **Sattelhöhe**: von der **Tretlagermitte** entlang der Sattelstütze bis zur **Oberseite des Sattels** messen
+
+In der gängigen Literatur liegt der Faktor zwischen 0,88 und 0,885 — die Unterschiede sind gering. Diese Formel liefert einen **Ausgangspunkt**, keinen Endwert.
+
+### Methode 3: Kniewinkel-Methode (die genaueste Selbstkontrolle)
+
+Der biomechanisch anerkanntere Standard: **In der tiefsten Kurbelposition sollte das Knie einen Beugewinkel von 25°–35° behalten** (Holmes-Methode).
+
+Selbst überprüfen kannst du das mit einem Seitenvideo: normal fahren (mit den üblichen Radschuhen, bei Klickpedalen eingeklickt), das Standbild bei tiefster Pedalposition auswählen und den Winkel zwischen Ober- und Unterschenkel messen.
+
+- Unter 25° (Bein zu gestreckt) → Sattel zu hoch
+- Über 35° (zu stark gebeugt) → Sattel zu niedrig
+
+### Grundsatz beim Einstellen
+
+**Immer nur 2–3 mm auf einmal verstellen und ein- bis zweimal fahren, bevor du weiter anpasst.** Der Körper braucht Zeit, sich an eine veränderte Sattelhöhe zu gewöhnen — eine zu große Anpassung auf einmal überdeckt das eigentliche Problem und erhöht das Verletzungsrisiko.
+
+Vor dem Verstellen die Ausgangsposition mit Klebeband oder Markierstift festhalten, um jederzeit zurückstellen zu können.
+
+## 2. Sattelposition vor/zurück
+
+Erst nach der Sattelhöhe die Position vor/zurück einstellen. Referenzstandard ist **KOPS** (Knee Over Pedal Spindle):
+
+In deiner normalen Fahrposition sitzen, die Kurbel in die **waagerechte 3-Uhr-Position** drehen — die senkrechte Linie von der Kniefront sollte dabei ungefähr durch die Pedalachse verlaufen.
+
+- Bei relativ langem Oberschenkel sitzt der Sattel meist weiter hinten
+- Bei relativ langem Unterschenkel sitzt der Sattel meist etwas weiter vorn und etwas höher
+
+> KOPS ist nur ein **Ausgangswert**, kein biomechanisches Gesetz. Am Ende zählt, dass die Kraftübertragung rund läuft, das Sitzbein gleichmäßig belastet wird und die Arme kein Körpergewicht tragen müssen.
+
+Nach dem Verstellen der Sattelposition **muss die Sattelhöhe erneut kontrolliert werden** — eine Verschiebung entlang der Schiene verändert auch die effektive Sattelhöhe.
+
+## 3. Die drei Griffpositionen
+
+Die drei Griffpositionen am Rennradlenker haben jeweils klar definierte Einsatzbereiche — **keine ist grundsätzlich besser, nur unterschiedlich passend.**
+
+### 1. Bremshebel-Oberseite (Hoods) — die vielseitigste
+
+Die Hände liegen oben auf den Brems-Schalt-Kombihebeln.
+
+- **Vorteile**: Balance zwischen Aerodynamik und Komfort; jederzeit Zugriff auf Bremsen und Schaltung; Wechsel zwischen Sitzen und Wiegetritt ohne Handpositionswechsel
+- **Geeignet für**: Fahrt in der Ebene, Anstiege, die meisten Gruppenfahrsituationen
+- Diese Position wird im Training und Rennen am längsten genutzt, auch auf langen Strecken bleibt sie komfortabel
+
+### 2. Lenkeroberseite (Tops) — am bequemsten
+
+Die Hände liegen auf dem geraden oberen Teil des Lenkers.
+
+- **Vorteile**: Hände am nächsten zum Körper, aufrechtere Rückenhaltung, bester Komfort
+- **Nachteile**: **kein sofortiger Zugriff auf die Bremsen**, schlechteste Aerodynamik, engerer Handabstand reduziert die Kontrolle
+- **Geeignet für**: **nur Situationen mit geringem Bremsbedarf** — leichte Anstiege, verkehrsarme, übersichtliche Straßen
+- **Nicht geeignet für**: hohes Tempo, Abfahrten, dichten Verkehr, Gruppenfahrten
+
+> Bei Gruppenfahrten mit dieser Griffposition besonders vorsichtig sein — du kannst nicht sofort bremsen, und für plötzliche Situationen in der Gruppe bleibt oft nur ein bis zwei Sekunden Reaktionszeit.
+
+### 3. Unterlenker (Drops) — beste Kontrolle
+
+Die Hände greifen den unteren, gebogenen Teil des Lenkers.
+
+- **Vorteile**: beste Kontrolle und Bremskraft (längerer Hebel für die Finger, stabilerer Griff); niedriger Schwerpunkt, nahezu waagerechter Rücken, optimale Aerodynamik
+- **Nachteile**: deutlich weniger komfortabel als die anderen Positionen, bei geringer Flexibilität ermüdet der untere Rücken schneller
+- **Geeignet für**: Sprints, Abfahrten, Gegenwind, Situationen mit maximalem Bremsbedarf
+
+> Wichtig: Form und Funktion unterscheiden sich je nach Lenkermodell erheblich — nicht jeder Lenker ist primär auf Handkomfort ausgelegt.
+
+## 4. Schaltungsfeinjustierung
+
+### Feinjustierschraube (Barrel Adjuster)
+
+Rennräder haben meist am **Schaltwerk selbst** und **an der Zugverlegung am Vorbau** eine Feinjustierschraube zur direkten Anpassung der Zugspannung.
+
+Typische Symptome und Abhilfe (mechanische Schaltung):
+
+- **Hochschalten langsam / erreicht das größte Ritzel nicht (nach innen)** → Zugspannung zu gering, Schraube gegen den Uhrzeigersinn herausdrehen, um die Spannung zu erhöhen
+- **Runterschalten langsam / erreicht das kleinste Ritzel nicht (nach außen)** → Zugspannung zu hoch, Schraube im Uhrzeigersinn hineindrehen, um die Spannung zu reduzieren
+- Jeweils **eine Viertel- bis halbe Umdrehung**, dabei die Kurbel drehen und die Schaltung testen
+
+### Anschlagschrauben (für Einsteiger*innen nicht empfohlen)
+
+Die mit **H** (High, kleinstes Ritzel) und **L** (Low, größtes Ritzel) markierten Schrauben am Schaltwerk begrenzen dessen Bewegungsbereich.
+
+Das Prinzip: Erst sicherstellen, dass die Kette bei den beiden Extremübersetzungen sauber begrenzt ist — sie darf weder die Schaltung beeinträchtigen noch „entgleisen" (in die Speichen fallen oder über das Ritzelpaket hinausrutschen). **Erst wenn das gewährleistet ist**, sollte über die Zugspannung die Schaltleistung feinjustiert werden.
+
+**Eine falsch eingestellte Anschlagschraube kann dazu führen, dass die Kette in die Speichen fällt und dabei Schaltwerk, Schaltauge oder sogar das Laufrad beschädigt. Für Einsteiger*innen nicht empfohlen — das übernimmt besser ein Fachgeschäft oder eine erfahrene Person aus der Gruppe.**
+
+### Elektronische Schaltung
+
+Die Feinjustierung bei Di2 / eTap / EPS erfolgt über den **Schalthebel oder die App**, ohne die Problematik der Zugspannung. Die Logik ist ein direkt festgelegter Positionsversatz des Schaltwerks pro Gang.
+
+Vor der Abfahrt den **Akkustand prüfen** — bei leerem Akku verliert man meist zuerst die Funktion des vorderen Umwerfers.
+
+## 5. Bremssysteme
+
+### Gängige Typen
+
+- **Felgenbremse (Caliper)**: die klassische Lösung am Rennrad. Einfacher Aufbau, geringes Gewicht, niedrige Wartungskosten, leicht selbst zu warten. Nachteil: deutlich reduzierte Bremsleistung bei Nässe, lange Abfahrten führen zu Felgenerhitzung
+- **Scheibenbremse (Disc)**: besteht aus Bremshebel, Bremsleitung oder -zug, Bremssattel, Bremsbelägen und Bremsscheibe. **Stärkere Bremskraft, linearere Dosierung, geringerer Leistungsverlust bei Nässe.** Nachteil: komplexerer Aufbau, höherer Preis, anspruchsvollere Wartung
+- **V-Brake**: hauptsächlich an Stadträdern, Reiserädern und Rädern mit geradem Lenker, an Rennrädern mit Rennlenker praktisch nicht verbreitet
+
+> **Egal welche Bremse: Bremsscheibe, Bremsbeläge und Felgenbremsflanke dürfen niemals mit Öl oder Fett in Berührung kommen.** Danach fällt die Bremsleistung drastisch ab und lässt sich meist nur durch den Austausch der Beläge beheben.
+
+Konkrete Bremstechnik (Verteilung vorn/hinten, Kurven, Regen, Hitzeabbau bei langen Abfahrten) findest du in → [Trittfrequenz, Schalten und Bremsen: drei zentrale Fahrtechniken](/de/knowledge/training/cadence-shifting-braking)
+
+---
+
+## Weiterlesen
+
+- Fahrtechnik → [Trittfrequenz, Schalten und Bremsen: drei zentrale Fahrtechniken](/de/knowledge/training/cadence-shifting-braking)
+- Vor der Abfahrt → [Ausrüstungscheckliste und ABC-Schnellcheck](/de/knowledge/training/pre-ride-check-abc)

--- a/frontend/src/content/knowledge/training/de/cadence-shifting-braking.md
+++ b/frontend/src/content/knowledge/training/de/cadence-shifting-braking.md
@@ -1,0 +1,168 @@
+---
+slug: cadence-shifting-braking
+category: skills
+title: 'Trittfrequenz, Schalten und Bremsen: drei zentrale Fahrtechniken'
+description: 'Die Trittfrequenz entscheidet, wie lange du fahren kannst. Das Schalten entscheidet, wie lange deine Knie mitmachen. Das Bremsen entscheidet, ob du sicher ankommst. Prinzipien, typische Fehler und ein Selbsttest für die Trittfrequenz.'
+author: ACC Club
+date: 2026-08-01
+tags:
+  - Fahrtechnik
+  - Trittfrequenz
+  - Bremsen
+  - Eaglet-Programm
+cover: /images/media/adventure/rad-race-120-2025/gallery/2025-sonntag.jpg
+---
+
+Wenn man Einsteiger*innen nur drei technische Tipps geben könnte, wären es diese: **eine sinnvolle Trittfrequenz nutzen**, **im richtigen Moment schalten**, **an der richtigen Stelle bremsen**.
+
+## 1. Trittfrequenz (Cadence)
+
+### Warum die Trittfrequenz wichtig ist
+
+Dieselbe Leistung lässt sich auf zwei Arten erbringen: „große Übersetzung + niedrige Trittfrequenz" oder „kleine Übersetzung + hohe Trittfrequenz":
+
+- **Niedrige Trittfrequenz, hohe Kraft** → hohe Muskelbelastung, schnelle Ermüdung der Muskelfasern, hoher Druck auf die Kniegelenke
+- **Hohe Trittfrequenz, geringe Kraft** → hohe Belastung von Herz und Kreislauf, aber geringere Muskel- und Gelenkbelastung
+
+Bei Ausdauerfahrten wird die **muskuläre Ermüdung meist früher zum limitierenden Faktor als die Herz-Kreislauf-Belastung.** Deshalb verlängert eine höhere Trittfrequenz mit geringerer Kraft pro Tretzyklus auf langen Strecken deutlich deine Ausdauer. Das ist auch, warum Profis durchgängig eine relativ hohe Trittfrequenz fahren.
+
+### Richtwerte
+
+| Situation | Trittfrequenzbereich |
+| --- | --- |
+| Fahrt in der Ebene / Intensitätstraining | **85–100 U/min** |
+| Anstieg | **70–85 U/min** |
+| Regenerationsfahrt | 80–95 U/min (leichte Übersetzung) |
+
+Bergauf ist man durch Steigung und Übersetzung eingeschränkt und erreicht meist nicht die Trittfrequenz der Ebene — **70–80 U/min zu halten ist bereits gut.**
+
+Wichtig: „Optimale Trittfrequenz" unterscheidet sich deutlich von Person zu Person. Trainierte Fahrer*innen wählen meist von selbst 85–95 U/min, aber das ist ein Bereich, kein Zielwert, den man erreichen muss. **Opfere die Laufruhe nicht für eine bestimmte Zahl.**
+
+### Ohne Fahrradcomputer einschätzen
+
+Achte auf die **Stabilität des Körpers**:
+
+- Runder, zügiger Tritt ohne das Gefühl von „ins Leere treten" oder „hochgeschleudert werden" → Trittfrequenz passt
+- Oberkörper pendelt beim Treten seitlich, Gesäß hüpft auf dem Sattel → **Trittfrequenz zu hoch**, übersteigt die aktuelle neuromuskuläre Kontrollfähigkeit
+- Jeder Tritt erfordert spürbare Kraft, das Tempo ruckelt → **Trittfrequenz zu niedrig**, Zeit für eine leichtere Übersetzung
+
+Trittfrequenztraining ist ein **langfristiger, bewusster Prozess** — im Kern geht es darum, auch bei hoher Trittfrequenz körperlich ruhig zu bleiben und mit dem Rad zu einer Einheit zu werden. Leichter gesagt als getan — das braucht kontinuierliches, gezieltes Üben.
+
+### Selbsttest: die eigene ökonomische Trittfrequenz finden
+
+Ein Vergleichstest, den du selbst durchführen kannst:
+
+1. Finde eine Strecke, die du **10 Minuten am Stück ohne Unterbrechung** fahren kannst, und nutze für jeden Test dieselbe
+2. **Erster Durchgang**: mit 80 U/min fahren, Zeit und subjektive Ermüdung (Skala 1–10) notieren
+3. 15–20 Minuten locker weiterfahren
+4. **Zweiter Durchgang**: mit 95–100 U/min fahren, wieder Zeit und Ermüdung notieren
+5. **Nach ein paar Tagen wiederholen**, diesmal in umgekehrter Reihenfolge (erst hohe, dann niedrige Trittfrequenz), um einen Reihenfolgeeffekt auszugleichen
+6. Daten vergleichen: **welche Trittfrequenz war schneller und fühlte sich weniger ermüdend an — das ist deine ökonomische Trittfrequenz**
+
+Für ein feineres Ergebnis kannst du die getesteten Trittfrequenzen weiter aufteilen: 80 / 85 / 90 / 95 / 100 / 110 U/min. Landest du am Ende bei 85–110 U/min am wohlsten, ist das ein gutes Zeichen — deine gewohnte Trittfrequenz liegt bereits in einem effizienten Bereich.
+
+> Ein einzelner Test hat eine kleine Stichprobe, das Ergebnis dient nur als Anhaltspunkt. Wichtig ist, den **Trend** zu beobachten, nicht einen exakten Wert zu finden.
+
+## 2. Schalten
+
+### Erstes Prinzip: weitertreten
+
+**Beim Schalten unbedingt weitertreten.**
+
+Das Prinzip: Der Umwerfer schiebt die Kette nur an die **neue Position**, tatsächlich auf das neue Ritzel oder Kettenblatt klettert sie durch die beim Treten erzeugte Kettenspannung. Schaltest du, während du nicht trittst, bewegt sich die Kette nicht; setzt du dann wieder Kraft ein, rastet sie mit einem Ruck ein — das schadet Kette, Ritzel und Kettenblättern.
+
+Aber **auch nicht schalten, wenn die Trittkraft am größten ist** (z. B. im Wiegetritt am Berg). Ideal ist: **weitertreten, aber die Trittkraft kurz reduzieren.**
+
+### Zweites Prinzip: vorausschauend schalten
+
+**Frühzeitig schalten, vorausschauend schalten.**
+
+Besonders am Berg: Fährst du mit einer relativ großen Übersetzung in einen Anstieg, wird es nach zwei, drei Tritten oft unmöglich weiterzutreten — die Kettenspannung ist dann sehr hoch, und beim Herunterschalten hört man häufig ein lautes Geräusch. Ein- oder zweimal ist das nicht schlimm, aber auf Dauer schadet es Kette, Schaltwerk, Ritzeln und Kettenblättern nachhaltig.
+
+**Richtig ist: schon vor dem Anstieg in den passenden Gang schalten.** Vor einer Steigung wird das vordere Kettenblatt meist rechtzeitig auf das kleine gewechselt.
+
+### Den richtigen Schaltzeitpunkt erkennen
+
+Mit zunehmender Steigung wird es immer schwerer, die bisherige Trittfrequenz zu halten. Der richtige Zeitpunkt zum Schalten: **in dem Moment, in dem du merkst, dass das Tempo gleich sinkt und die Trittfrequenz schwer zu halten wird** — nicht erst, wenn du gar nicht mehr weitertreten kannst.
+
+- **Zu früh geschaltet** → plötzlicher Widerstandsverlust, Gefühl von „ins Leere treten", abruptes Abbremsen; die Stützkraft am Knie verschwindet plötzlich, ebenfalls ein Verletzungsrisiko
+- **Zu spät geschaltet** → der Widerstand steigt kontinuierlich, die Trittfrequenz lässt sich nicht mehr halten, man muss den Körper einsetzen oder mit viel mehr Kraft treten, um die Trittfrequenz notdürftig zu halten — **hohe Belastung für das Kniegelenk**
+
+Beides ist ungünstig. Zu frühes und zu spätes Schalten können beide zu Gelenkverletzungen führen.
+
+### Zusammenspiel von vorderer und hinterer Schaltung
+
+- **Kleine Streckenänderungen** (leichte Steigung, Wellen) → nur mit dem Schaltwerk hinten fein nachjustieren
+- **Große Streckenänderungen** (langer Anstieg, lange Abfahrt) → erst den Umwerfer vorne, dann hinten feinjustieren
+
+### Kreuzverzahnung vermeiden (Cross-Chaining)
+
+**Großes Kettenblatt + größtes Ritzel** oder **kleines Kettenblatt + kleinstes Ritzel** verursacht eine starke Schrägstellung der Kette — das führt zu Geräuschen, beschleunigtem Verschleiß, reduzierter Übertragungseffizienz und im Extremfall zum Kettenabwurf.
+
+Brauchst du diese Kombinationen, ist das ein Zeichen, dass du das vordere Kettenblatt wechseln solltest.
+
+> Auf langen Strecken wechselt die Situation ständig, eine „Allzweck-Übersetzung" gibt es nicht. **Häufig und rechtzeitig schalten.**
+
+## 3. Bremsen
+
+### Vorn- oder Hinterradbremse?
+
+Beim Bremsen verlagert sich der Schwerpunkt nach vorn, **das Vorderrad gewinnt an Grip, das Hinterrad verliert.** Daher:
+
+- Die **Vorderradbremse** liefert den Großteil der Bremskraft (ca. 70 %), aber bei zu weit vorn liegendem Schwerpunkt kann das Hinterrad abheben
+- Die **Hinterradbremse** bremst schwächer und eignet sich zum Feinjustieren des Tempos; zu starkes Ziehen blockiert das Hinterrad und führt zu seitlichem Ausbrechen und instabilem Schwerpunkt
+
+**In der Regel sollte keine der beiden allein genutzt werden.** Richtig ist, **vorn und hinten gleichzeitig zu betätigen**, zunächst mit gleichmäßigem, dosiertem Antippen; braucht es mehr Verzögerung, den Druck kontinuierlich leicht erhöhen; ist es immer noch zu schnell, den Druck langsam weiter steigern.
+
+**Auf keinen Fall die Bremse plötzlich mit voller Kraft ziehen.**
+
+Bei starker Bremsung **den Schwerpunkt aktiv nach hinten verlagern** (Gesäß leicht vom Sattel nach hinten), so kann mehr Vorderbremskraft genutzt werden, ohne über den Lenker zu gehen.
+
+### Kurven: Verzögerung vor der Kurve abschließen
+
+Der wichtigste Grundsatz: **schon vor der Kurve auf Kurvengeschwindigkeit abbremsen, nicht während der Kurve.**
+
+Das Prinzip: Der Grip eines Reifens ist begrenzt und muss gleichzeitig für **Lenken** und **Bremsen** ausreichen. In der Kurve verändert sich der Grip am Vorderrad sehr komplex — blockiert Vorder- oder Hinterrad unerwartet, führt das sofort zum Sturz.
+
+Deshalb:
+
+- **Verzögerung vor der Kurve abschließen**
+- Muss in der Kurve gebremst werden, dann gleichmäßig vorn/hinten und sehr sanft
+- **Starkes Bremsen in der Kurve vermeiden**
+- Die Linie **außen–innen–außen** fahren, der Kurvenscheitel liegt nahe der Innenseite, so lässt sich mit größerem Kurvenradius fahren
+- Das innere Pedal **oben halten**, um Bodenkontakt zu vermeiden
+
+### Verschiedene Situationen
+
+**Regen**:
+
+- Bei Felgenbremsen bildet sich ein Wasserfilm auf der Bremsflanke, der Bremsbelag kann nicht sofort Reibung erzeugen. **Während der Fahrt die Bremse kurz antippen**, damit der Belag den Wasserfilm von der Flanke wischt — die Bremsleistung erholt sich danach deutlich
+- Scheibenbremsen sind deutlich weniger vom Regen betroffen, zeigen aber ebenfalls eine kurze anfängliche Verzögerung
+- Insgesamt: **Bremsweg auf das Doppelte gegenüber trockener Fahrbahn einplanen**
+
+**Holpriger Untergrund**:
+
+- Empfohlen: **Unterlenker** greifen, die Finger umschließen den Lenker fest, so löst du dich bei Stößen nicht so leicht
+- Gesäß leicht vom Sattel abheben, Arme und Beine leicht angewinkelt, den Körper als Stoßdämpfer nutzen, um Erschütterungen zu reduzieren
+
+**Enge Kurven an steilen Abschnitten**:
+
+- **Unterlenker** greifen, Schwerpunkt nach hinten verlagern
+- Darauf achten, dass das kurveninnere Pedal nicht den Boden berührt
+
+**Lange Abfahrt**:
+
+- **Intervallweise bremsen**, nicht dauerhaft auf der Bremse bleiben
+- Felgenbremse: Reibung zwischen Belag und Alu- oder Carbonfelge über längere Zeit erzeugt Hitze, was zum Reifenplatzen oder zu Schäden an Carbonfelgen führen kann. Zwischendurch anhalten, um vollständig abzukühlen
+- Scheibenbremse: erhitzt sich ebenfalls und verliert an Bremskraft (Fading), erst nach dem Abkühlen der Scheibe weiterfahren
+
+### Vorbereitung vor der Abfahrt
+
+Ist eine lange Abfahrt Teil der geplanten Strecke, solltest du **vor der Abfahrt die Bremszüge oder -leitungen auf Unversehrtheit prüfen** und das Bremssystem an einem nahegelegenen kurzen Anstieg/Abstieg testen, um die Bremsflächen auf Auffälligkeiten, Verschmutzung oder Kratzer zu kontrollieren.
+
+---
+
+## Weiterlesen
+
+- Radeinstellung → [Sattelhöhe, Griffposition und Schaltung](/de/knowledge/training/bike-setup-basics)
+- Fahrregeln für die Gruppe → [Fahrregeln für die Gruppe: Handzeichen, Formation und Sicherheitsabstand](/de/knowledge/training/acc-group-riding-rules)

--- a/frontend/src/content/knowledge/training/de/german-cycling-traffic-rules.md
+++ b/frontend/src/content/knowledge/training/de/german-cycling-traffic-rules.md
@@ -1,0 +1,131 @@
+---
+slug: german-cycling-traffic-rules
+category: safety
+title: 'Deutsche Verkehrsregeln fürs Radfahren: ein Leitfaden für Einsteiger'
+description: Das Fahrrad ist in Deutschland ein vollwertiges Verkehrsmittel — mit klaren Rechten und ebenso klaren Pflichten. Die wichtigsten Punkte der StVO für Radfahrende, kompakt zusammengefasst — von der Radwegbenutzungspflicht bis zur rechtlichen Definition eines geschlossenen Verbands.
+author: ACC Club
+date: 2026-08-04
+featured: true
+tags:
+  - Sicherheit
+  - Verkehrsregeln
+  - Deutschland
+  - Eaglet-Programm
+cover: /images/shared/stock/munich-cycling.jpg
+---
+
+In Deutschland ist das Fahrrad rechtlich gesehen ein **Fahrzeug** — kein Spielzeug und keine Verlängerung des Fußgängerverkehrs. Das bedeutet: Mit Ausnahme von Autobahnen und Kraftfahrstraßen haben Radfahrende auf der Fahrbahn dieselben Rechte wie Autofahrende — und müssen sich auch an dieselben Regeln halten.
+
+Dieser Artikel orientiert sich an der Straßenverkehrs-Ordnung (StVO). **Gesetze werden geändert, und einzelne Streckenabschnitte können besondere Beschilderung haben — maßgeblich sind immer die Beschilderung vor Ort und der aktuelle Gesetzestext.**
+
+## 1. Wann ist ein Radweg verpflichtend?
+
+Das ist der häufigste Irrtum bei Einsteigern. Die Antwort: **nur, wenn eines der blauen, runden Gebotszeichen aufgestellt ist.**
+
+| Zeichen | Nummer | Bedeutung |
+| --- | --- | --- |
+| Blau mit weißem Fahrrad | **Zeichen 237** | Radweg, **Benutzungspflicht** |
+| Blau mit Fahrrad + Fußgänger (übereinander getrennt) | **Zeichen 240** | Gemeinsamer Geh- und Radweg, **Benutzungspflicht** |
+| Blau mit Fahrrad + Fußgänger (nebeneinander getrennt) | **Zeichen 241** | Getrennter Rad-/Gehweg, **Benutzungspflicht** auf der Radseite |
+
+§2 Abs. 4 StVO stellt klar:
+
+> „Eine Pflicht, Radwege in der jeweiligen Fahrtrichtung zu benutzen, besteht nur, wenn dies durch Zeichen 237, 240 oder 241 angeordnet ist."
+
+Mit anderen Worten: **Liegt neben der Fahrbahn ein Radweg, ohne dass eines dieser drei blauen Zeichen aufgestellt ist, darfst du völlig legal auf der Fahrbahn weiterfahren.** Ein rechter Radweg ohne Benutzungspflicht ist ein „anderer Radweg" — die Nutzung ist freigestellt.
+
+Daneben gibt es Verbotszeichen (weiß mit rotem Rand), die das Befahren mit dem Rad grundsätzlich untersagen — diese sind natürlich verbindlich.
+
+> Praxistipp: Auch wenn die Radwegnutzung freigestellt ist, lohnt sich der Blick auf die tatsächliche Sicherheit. Ein schmaler, von parkenden Autos zugestellter Radweg mit schlechter Sichtbarkeit an Kreuzungen kann riskanter sein als die Fahrbahn.
+
+## 2. Darf man nebeneinander fahren?
+
+**Ja, solange der Verkehr dadurch nicht behindert wird.**
+
+§2 Abs. 4 StVO:
+
+> „Mit Fahrrädern darf nebeneinander gefahren werden, wenn dadurch der Verkehr nicht behindert wird."
+
+Diese Formulierung stammt aus der Novelle von 2020 — vorher galt „grundsätzlich verboten, Ausnahmen erlaubt", seither gilt „grundsätzlich erlaubt, bei Behinderung untersagt". Der praktische Maßstab: Kann der nachfolgende Verkehr wegen des Nebeneinanderfahrens nicht mehr sicher überholen? In engen Straßen oder bei viel Verkehr am besten von selbst in den Einzelverkehr wechseln.
+
+## 3. Die rechtliche Definition eines geschlossenen Verbands
+
+Das ist der Punkt, den jede Gruppenausfahrt kennen muss. §27 Abs. 1 StVO:
+
+> „Mehr als 15 Rad Fahrende dürfen einen geschlossenen Verband bilden. Dann dürfen sie zu zweit nebeneinander auf der Fahrbahn fahren."
+
+Die genaue Schwelle:
+
+- **Mehr als 15, also ab 16 Fahrenden** → kann einen Verband bilden, darf legal zu zweit nebeneinander fahren
+- **15 oder weniger** → bildet keinen Verband, es gelten die allgemeinen Regeln (§2 Abs. 4: nebeneinander erlaubt, solange niemand behindert wird)
+
+Die rechtliche Bedeutung eines Verbands: **Der gesamte Verband gilt als eine Fahrzeugeinheit.** Fährt die Spitze bei Grün über eine Kreuzung und die Ampel springt danach auf Rot, dürfen die restlichen Mitglieder trotzdem folgen — der Verband darf nicht zerrissen werden. Voraussetzung dafür ist allerdings, dass der Verband als erkennbare, geschlossene, organisierte Einheit auftritt — eine über mehrere hundert Meter auseinandergezogene Gruppe bildet keinen Verband.
+
+> Ob die Verbandsregelung anwendbar ist, hängt von der tatsächlichen Teilnehmerzahl am jeweiligen Tag ab und sollte vor der Abfahrt gemeinsam geklärt werden. **Nicht einfach annehmen.**
+
+## 4. Kreuzungen und Vorfahrt
+
+### Rechts vor links
+
+An Kreuzungen ohne Vorfahrtsschilder oder Ampeln (typisch in Wohngebieten und Tempo-30-Zonen) **hat der Verkehr von rechts Vorfahrt.** Diese Regel gilt gleichermaßen für Radfahrende — du musst dem Verkehr von rechts Vorfahrt gewähren, der Verkehr von links dir.
+
+In Tempo-30-Zonen gilt an den meisten Kreuzungen rechts-vor-links, **und zwar ohne jede Beschilderung**. Das ist die häufigste Unfallursache bei ausländischen Radfahrenden: die Annahme, man befahre eine Hauptstraße, obwohl das rechtlich gar nicht der Fall ist.
+
+### Ampeln
+
+§37 StVO:
+
+- Gibt es eine **eigene Radverkehrsampel**, gilt deren Signal
+- Ohne eigene Radverkehrsampel gilt bei Fahrt auf der Fahrbahn **die Ampel für den Kfz-Verkehr**
+- **Fußgängerampeln gelten nicht für Radfahrende** (außer du schiebst dein Rad — dann giltst du rechtlich als Fußgänger)
+
+### Zwei Arten des Linksabbiegens
+
+1. **Direktes Linksabbiegen**: auf der Fahrbahn rechtzeitig über die Schulter schauen, mit dem linken Arm anzeigen, in die Linksabbiegespur einordnen — wie ein Auto abbiegen. Geeignet bei Geschwindigkeit nahe am übrigen Verkehr und guter Übersicht an der Kreuzung
+2. **Indirektes Linksabbiegen** (zweiphasig): erst geradeaus über die Kreuzung bis zum rechten Wartebereich der Gegenrichtung, dort um 90° drehen und bei Grün geradeaus weiterfahren. An manchen Kreuzungen ist diese Variante durch Beschilderung sogar vorgeschrieben
+
+Für Einsteiger und größere Gruppen ist indirektes Linksabbiegen deutlich sicherer.
+
+## 5. Fahrradstraße und Fahrrad-Zone
+
+**Fahrradstraße (Zeichen 244.1)**:
+
+- Das Fahrrad steht im Mittelpunkt, **Nebeneinanderfahren ist erlaubt** und nicht an das Kriterium „keine Behinderung" gebunden
+- Höchstgeschwindigkeit **30 km/h**, Kfz-Verkehr darf Radfahrende weder behindern noch gefährden
+- Kfz-Verkehr ist **grundsätzlich untersagt**, außer ein Zusatzzeichen erlaubt ihn ausdrücklich (z. B. „Anlieger frei", „Kfz frei")
+
+**Fahrrad-Zone (Zeichen 244.3)**: gleiche Regelung, gilt aber für ein ganzes Gebiet statt für eine einzelne Straße.
+
+## 6. Beleuchtung und gesetzliche Ausstattung (StVZO)
+
+Bei Dunkelheit oder schlechter Sicht **muss** die Beleuchtung eingeschaltet sein. Nach §67 StVZO braucht ein Fahrrad:
+
+- Vorn ein **weißes Frontlicht** und einen weißen Reflektor
+- Hinten ein **rotes Rücklicht** und einen roten Reflektor
+- **Zwei voneinander unabhängige Bremsen**
+- Eine **Klingel**
+- Reflektoren an Pedalen und Rädern (Reflexstreifen oder reflektierende Reifen)
+
+Seit der Novelle von 2017 sind **batterie- bzw. akkubetriebene Leuchten legal**, ein Nabendynamo ist nicht mehr vorgeschrieben. Blinkende Frontleuchten sind in Deutschland jedoch nicht zulässig — das Frontlicht muss dauerhaft leuchten.
+
+## 7. Alkohol
+
+Auch Radfahrende unterliegen den Regelungen zur Fahrtüchtigkeit unter Alkoholeinfluss:
+
+- **Ab 1,6 ‰**: absolute Fahruntüchtigkeit, Straftatbestand, kann auch zum Entzug der **Kfz**-Fahrerlaubnis führen
+- **Ab 0,3 ‰** bei zusätzlichen Fahrauffälligkeiten oder nach einem Unfall: bereits strafbar
+
+Nach dem Biergarten mit dem Rad nach Hause fahren solltest du also genau abwägen.
+
+---
+
+## Quellen und Gesetzestexte
+
+- [StVO Volltext (gesetze-im-internet.de)](https://www.gesetze-im-internet.de/stvo_2013/)
+- [StVO §2 — Straßenbenutzung](https://www.gesetze-im-internet.de/stvo_2013/__2.html)
+- [StVO §27 — Geschlossener Verband](https://www.gesetze-im-internet.de/stvo_2013/__27.html)
+
+## Weiterlesen
+
+- Vor der Abfahrt → [Ausrüstungscheckliste und ABC-Schnellcheck](/de/knowledge/training/pre-ride-check-abc)
+- Fahrregeln für die Gruppe → [Fahrregeln für die Gruppe: Handzeichen, Formation und Sicherheitsabstand](/de/knowledge/training/acc-group-riding-rules)

--- a/frontend/src/content/knowledge/training/de/pre-ride-check-abc.md
+++ b/frontend/src/content/knowledge/training/de/pre-ride-check-abc.md
@@ -1,0 +1,103 @@
+---
+slug: pre-ride-check-abc
+category: safety
+title: 'Vor der Abfahrt: Ausrüstungscheckliste und ABC-Schnellcheck'
+description: Drei Minuten vor jeder Abfahrt für den ABC Quick Check nehmen und die meisten mechanischen Probleme und Plattfüße unterwegs lassen sich vermeiden. Mit vollständiger Ausrüstungs- und Werkzeugliste.
+author: ACC Club
+date: 2026-08-05
+featured: true
+tags:
+  - Sicherheit
+  - Ausrüstung
+  - Eaglet-Programm
+cover: /images/shared/stock/canyon-road-bike.webp
+---
+
+Die häufigste Unterbrechung unterwegs ist nicht, dass jemand körperlich schlapp macht, sondern ein Problem, das schon drei Minuten vor der Abfahrt zu erkennen gewesen wäre: zu wenig Luft im Reifen, abgefahrene Bremsbeläge, ein nicht festgezogener Schnellspanner.
+
+Der folgende Ablauf funktioniert egal ob solo oder in der Gruppe unterwegs — mit etwas Übung dauert er drei Minuten.
+
+## 1. Persönliche Ausrüstung
+
+| Ausrüstung | Anforderung | Erklärung |
+| --- | --- | --- |
+| **Helm** | Pflicht | In Deutschland gesetzlich für Erwachsene nicht vorgeschrieben, aber bei den meisten Gruppenausfahrten Pflicht. Ein Helm ist ein Verschleißteil — nach einem Aufprall solltest du ihn austauschen, auch wenn er äußerlich unbeschädigt aussieht |
+| **Brille** | Dringend empfohlen | Schützt vor Wind, Insekten und aufgewirbelten Steinen. Getönte Gläser oder je nach Wetter helle/dunkle Gläser wechseln |
+| **Handschuhe** | Dringend empfohlen | Bei einem Sturz fängst du dich instinktiv mit den Händen ab — Handschuhe reduzieren Schürfwunden deutlich und dämpfen zudem Vibrationen von der Straße |
+| **Klickschuhe + Klickpedale** | Optional | Verbessern die Trittwirkung, aber Einsteiger sollten das Ein- und Auskuppeln erst auf dem Rasen oder mit Halt an der Wand üben, bevor sie in eine Gruppe gehen |
+| **Radtrikot** | Empfohlen | Eine Hose mit Sitzpolster reduziert Scheuerstellen auf langen Strecken deutlich; die Trikottaschen eignen sich besser zum Verstauen von Verpflegung als ein Rucksack |
+
+> Tipp für Einsteiger: Wenn du zum ersten Mal mit Klickpedalen in einer Gruppe fährst, sag den anderen vorher Bescheid. Anhalten, Kreuzungen und das Anfahren an Steigungen sind die häufigsten Situationen für Stürze beim Auskuppeln.
+
+## 2. Der ABC Quick Check (Abfahrtscheck)
+
+Ein international gebräuchlicher Merkspruch für den Check vor der Abfahrt — dauert 30 Sekunden bis 3 Minuten.
+
+### A — Air (Luftdruck)
+
+Mit der Hand am Reifen drücken zeigt nur „Luft drin oder nicht", nicht „genug oder nicht genug". **Nutze eine Standpumpe mit Manometer** und prüfe vor jeder Fahrt. Rennradreifen verlieren täglich von selbst etwas Luft, auch wenn du erst gestern aufgepumpt hast.
+
+Richtwerte für den Einstieg (bei ca. 70 kg Körpergewicht, Drahtreifen mit Schlauch):
+
+| Reifenbreite | Vorderrad | Hinterrad |
+| --- | --- | --- |
+| 25c | 6,0–6,5 bar | 6,5–7,0 bar |
+| 28c | 5,0–5,5 bar | 5,5–6,0 bar |
+| 32c | 4,0–4,5 bar | 4,5–5,0 bar |
+
+Ein paar Grundsätze:
+
+- **Die auf der Reifenflanke aufgedruckten Min-/Max-Werte sind die absolute Grenze** — keine Empfehlung sollte diese überschreiten
+- Pro 10 kg Körpergewicht mehr oder weniger etwa 0,3–0,5 bar anpassen
+- Das Hinterrad trägt mehr Last, daher 0,3–0,5 bar höher als vorne
+- Bei Tubeless-Reifen kann der Druck 0,5–1,0 bar niedriger sein als in der Tabelle
+- Bei Regen oder auf holprigem Untergrund den Druck etwas senken — das verbessert Grip und Komfort
+
+Aktuelle Praxistests zeigen zunehmend: Auf realen Straßen senkt zu hoher Luftdruck die Rolleffizienz eher, weil Vibrationsverluste zunehmen. **„So hart wie möglich pumpen für maximale Geschwindigkeit" ist eine überholte Faustregel.**
+
+### B — Brakes (Bremsen)
+
+- Beim Ziehen der Bremse sollte das Gefühl **progressiv und kraftvoll** sein, nicht bis zum Anschlag ohne Wirkung
+- Felgenbremse: Belagdicke und Rillenprofil prüfen, Bremsbelag sollte exakt auf der Felgenflanke sitzen und nicht die Reifenflanke berühren
+- Scheibenbremse: Belagdicke prüfen (unter 0,5 mm austauschen), Rad drehen und auf anhaltendes Schleifgeräusch achten
+- **Bremsscheiben und -beläge dürfen niemals mit Öl oder Fett in Berührung kommen.** Das führt zu drastisch reduzierter Bremsleistung, die sich meist nur durch neue Beläge beheben lässt
+
+### C — Chain / Cranks (Antrieb)
+
+- Kette auf Sauberkeit und trockene Laufgeräusche prüfen, bei Bedarf Kettenöl nachfüllen
+- Vorderer und hinterer Umwerfer sollten sauber schalten, alle Gänge sollten sich problemlos einlegen lassen
+- Kurbel drehen und auf Spiel oder ungewöhnliche Geräusche achten
+
+### Quick — Schnellspanner / Steckachse
+
+Sitzen die Schnellspanner oder Steckachsen an Vorder- und Hinterrad **vollständig fest**? Das wird am häufigsten übersehen — mit den schwerwiegendsten Folgen. Ein Schnellspannhebel sollte beim Schließen spürbaren Widerstand erfordern, und die Hebelposition darf nach dem Schließen nicht am Rahmen oder an der Bremsscheibe anstehen.
+
+### Check — Gesamtcheck
+
+Das Rad anheben und leicht auf den Boden aufsetzen, auf lockere Teile oder Klappergeräusche achten; Sattel- und Vorbauschrauben, Fahrradcomputer und Beleuchtung auf festen Sitz prüfen.
+
+## 3. Werkzeug für unterwegs
+
+Auf längeren Fahrten unbedingt mitnehmen — **und wissen, wie man es benutzt**:
+
+- **Ersatzschlauch** ×1–2 (Ventiltyp und -länge müssen zu deinem Laufradsatz passen)
+- **Reifenheber** ×2
+- **Kompakte Handpumpe oder CO₂-Kartuschen** (CO₂ ist schnell, aber Einmalverbrauch — mindestens eine Pumpe sollte immer dabei sein)
+- **Multitool** (mit gängigen Innensechskant- und T25-Torx-Größen)
+- **Kettenschloss** (passend zur Kettengeschwindigkeit — ein 11-fach-Kettenschloss passt nicht auf eine 12-fach-Kette)
+
+> In der Gruppe muss nicht jede*r alles dabeihaben, aber **jede*r sollte den passenden Ersatzschlauch für das eigene Rad mitführen** — der Schlauch von jemand anderem passt nicht zwangsläufig auf deinen Laufradsatz.
+
+## 4. Elektronik
+
+- **Fahrradcomputer / Handy**: Akkustand prüfen, Route vorab importieren
+- **Elektronische Schaltung**: vor der Abfahrt den Akkustand prüfen. Bei leerem Akku verliert man meist zuerst die Funktion des vorderen Umwerfers, das hintere Schaltwerk hält noch eine Weile durch
+- **Beleuchtung**: auch bei Tageslicht empfehlenswert mitzuführen — Tunnel im Gebirge, plötzlicher Wetterumschwung oder eine verzögerte Fahrt können dazu führen, dass du bei Dunkelheit unterwegs bist
+
+---
+
+## Weiterlesen
+
+- Verkehrsregeln und Vorfahrt → [Deutsche Verkehrsregeln fürs Radfahren: ein Leitfaden für Einsteiger](/de/knowledge/training/german-cycling-traffic-rules)
+- Fahrregeln für die Gruppe → [Fahrregeln für die Gruppe: Handzeichen, Formation und Sicherheitsabstand](/de/knowledge/training/acc-group-riding-rules)
+- Radeinstellung → [Grundlegende Radeinstellung: Sattelhöhe, Griffposition und Schaltung](/de/knowledge/training/bike-setup-basics)

--- a/frontend/src/content/knowledge/training/en/acc-group-riding-rules.md
+++ b/frontend/src/content/knowledge/training/en/acc-group-riding-rules.md
@@ -1,0 +1,141 @@
+---
+slug: acc-group-riding-rules
+category: safety
+title: 'Group Riding Etiquette: Hand Signals, Formation, and Following Distance'
+description: Riding in a group isn't about going fast — it's about making every move you make predictable to the people around you. Hand signals and calls, formation rules, following distance, rotation, and the single most important rule — never overlap wheels.
+author: ACC Club
+date: 2026-08-03
+featured: true
+tags:
+  - safety
+  - group riding
+  - eaglet program
+cover: /images/media/adventure/rad-race-120-2025/gallery/2026-group-turn.jpg
+---
+
+Riding alone, you're only responsible for yourself. Riding in a group, everyone behind you depends on your movements being **predictable**.
+
+That's the core principle of group riding — every other rule follows from it:
+
+> **Stay predictable. Never make a move the rider behind you can't react to in time.**
+
+## 1. Hard limits
+
+The following rules have no exceptions. Most groups treat them as zero-tolerance — a violation gets called out on the spot, and repeated violations get you pulled from the ride:
+
+### 1. Never overlap wheels
+
+**Overlapping** means your front wheel and the rear wheel of the rider ahead of you occupy the same lateral space. It's the single leading cause of crashes in group rides.
+
+The mechanics are simple: if the rider ahead shifts sideways even a few dozen centimeters for any reason (avoiding a pothole, dodging something, normal drift), they'll clip your front wheel from the side. **A front wheel hit from the side loses balance instantly** — you almost never save it, and you typically go down toward the inside of the group, taking other riders with you.
+
+The rider ahead **has no idea and can't do anything about it**, because they can't see you. **Avoiding overlap is 100% the responsibility of the rider behind.**
+
+### 2. No emergency braking
+
+A hard brake in a group triggers a chain reaction. When you need to slow down:
+
+- First, **coast** without pedaling, or sit up slightly for more wind resistance
+- If you must brake, do it **gently and progressively**, calling "slowing" behind you
+- Only brake hard in a genuine emergency
+
+This applies especially to whoever's leading: **never brake hard while leading the group.** Look ahead and slow down early.
+
+### 3. Always pass on the left
+
+Passing on the right is a hard no — the right side is a blind spot for the rider ahead, and it's also where the curb and pedestrians are.
+
+After passing, **don't cut back in immediately.** Confirm you're fully clear (you should be able to see the rider you passed in your peripheral vision behind you) before merging smoothly back.
+
+### 4. Always check over your shoulder before changing lanes or merging
+
+Mirrors and peripheral vision are no substitute for an actual **shoulder check**, paired with a hand signal.
+
+## 2. Hand signals and calls
+
+A group communicates through hand signals and verbal calls. **Every signal has to be passed rider-to-rider down the line** — the people at the back need the information most and can see the road least.
+
+### Common hand signals
+
+| Signal | Motion | Meaning |
+| --- | --- | --- |
+| **Stop** | Raise a flat, open palm above the shoulder | Group needs to stop ahead |
+| **Slow down** | Palm facing down, small up-down wave | Group needs to slow ahead |
+| **Pothole / obstacle** | Point downward toward the hazard, on the side it's on | A hole, drain cover, or debris on that side of the road |
+| **Gravel / loose surface** | Hand out to the side, fingers spread and lightly shaken | Loose surface ahead, watch your grip |
+| **Turning left / right** | Extend the arm on that side straight out | About to turn |
+| **Move over / single file** | Hand behind your back, pointing in the direction the group should shift | Formation needs to narrow |
+| **Vehicle / pedestrian ahead** | Hand behind your back, waving inward | Hazard on that side, move in |
+
+### Common verbal calls
+
+Hand signals get blocked by bodies in a group, so critical information **has to be called out at the same time**:
+
+"**Stopping!**" "**Slowing!**" "**Hole!**" "**Car back!**" (vehicle approaching from behind) "**Car up!**" (vehicle ahead or oncoming) "**Single file!**"
+
+## 3. Formation
+
+**Single file** is the default formation — use it on narrow roads, in heavy traffic, in poor visibility, on climbs and descents, and through intersections.
+
+**Two abreast** works on wide, quiet roads at a steady flat-road pace. For the legal basis, see [German Traffic Rules for Cyclists](/en/knowledge/training/german-cycling-traffic-rules):
+
+- **16 riders or more** can form a closed formation (Verband) under StVO §27 and legally ride two abreast
+- **15 or fewer** falls under §2(4): side by side only when it doesn't obstruct traffic
+
+When riding two abreast, **the two riders should stay level with each other**, shoulder to shoulder — not staggered front-to-back, which eats into the space available for riders behind.
+
+### Clearing intersections
+
+- **Cross as a group**, don't let it split. If the whole group can't make it through, the front half should slow and wait somewhere safe
+- Shift to **single file** before the intersection, then reform afterward
+- **Every rider is responsible for judging the intersection for themselves** — don't blindly follow the rider ahead of you. Them making it through doesn't mean you will, especially on a yellow light
+
+## 4. Following distance
+
+### How much distance
+
+| Situation | Distance |
+| --- | --- |
+| Beginners / mixed group | 1–2 bike lengths (roughly 2–4 m) |
+| Experienced group, flat cruising | Half a wheel to one wheel |
+| **Downhill** | **Noticeably more — 2–3 bike lengths** |
+| Wet roads | Double whatever the base distance would otherwise be |
+
+### Look further ahead
+
+The most common beginner mistake is **fixating on the rear wheel right in front of you.** That leaves you only able to react to that one rider's movements, and the reaction is inherently late.
+
+The right approach: **look past the rider ahead of you, toward the next 3–5 riders**, and use your peripheral vision to hold your distance from the one directly in front. That way you see road conditions almost as soon as the riders at the front do, instead of the information trickling back rider by rider.
+
+## 5. Rotation
+
+Rotation is how a group shares the wind resistance evenly. After a turn at the front, a rider falls back and the next one takes over.
+
+### Basic process
+
+1. Whoever's leading takes a pull (30 seconds to 2 minutes for beginner groups — don't overdo it)
+2. Signal behind you (flick an elbow out or call it), then pull off **smoothly** to the side
+3. **Keep pedaling, don't slow down** — easing off naturally lets you drift back. Braking hard causes rear-end collisions
+4. Drop back along the side of the group, check behind you, and merge back in
+
+### Rotation direction
+
+Rotation direction isn't fixed — it depends on the **wind**: **the leeward side is the side you drop back on.** That way the rider dropping back gets more wind resistance and falls back more naturally, while the advancing line stays sheltered.
+
+With no wind or an unclear wind direction, both directions are used in practice — there's no absolute right answer.
+
+> **What matters is that the whole group uses the same direction.** Settle it before you set off — two riders moving in opposite directions collide head-on, which is genuinely dangerous.
+
+### Notes for beginners
+
+- **You don't have to rotate the first time you join a group ride.** Sit in the back half and let people know beforehand
+- **Don't accelerate when you take a pull.** A lot of beginners unconsciously push harder once they're at the front, which ends up stringing the group out
+- If it's getting hard, **just sit out a rotation** — signal behind you and let someone else take over. Nobody thinks less of you for it. Blowing up the group is the actual problem
+
+---
+
+## Next steps
+
+- Pre-ride checks → [Gear List and the ABC Quick Check](/en/knowledge/training/pre-ride-check-abc)
+- Legal basis → [German Traffic Rules for Cyclists](/en/knowledge/training/german-cycling-traffic-rules)
+- Riding technique → [Cadence, Shifting, and Braking: Three Core Riding Skills](/en/knowledge/training/cadence-shifting-braking)

--- a/frontend/src/content/knowledge/training/en/bike-setup-basics.md
+++ b/frontend/src/content/knowledge/training/en/bike-setup-basics.md
@@ -1,0 +1,144 @@
+---
+slug: bike-setup-basics
+category: skills
+title: 'Bike Setup Basics: Saddle Height, Hand Position, and Shifting'
+description: '"Why does pedaling hurt," "why does my knee ache," "why won''t it shift right" — for most beginners, the answer isn''t fitness, it''s bike setup. A complete guide to saddle height, fore-aft position, the three hand positions, and shifting fine-tuning.'
+author: ACC Club
+date: 2026-08-02
+tags:
+  - bike setup
+  - bike fit
+  - eaglet program
+cover: /images/shared/stock/bike-fitting.jpg
+---
+
+The three questions beginners ask most — "why does pedaling hurt," "why does my knee ache," "why won't it shift right" — almost always trace back to bike setup, not fitness.
+
+This article covers the basic adjustments you can make yourself. **For a deeper fit adjustment, especially if you're already dealing with persistent pain, see a professional fitter.**
+
+## 1. Saddle height
+
+Saddle height has the biggest impact and is also the easiest thing to get wrong. **Too high** causes the pelvis to rock side to side while pedaling, straining the back of the knee and the hamstrings. **Too low** puts excess pressure on the front of the knee and noticeably reduces pedaling efficiency.
+
+### Method 1: heel method (quick starting point)
+
+Sit on the saddle (have someone hold the bike, or lean against a wall), keep your **pelvis level**, turn the crank to its lowest point (6 o'clock), and rest your **heel** on the pedal.
+
+Your knee should be **just fully extended**, with no tilt in the pelvis toward that side. That gives you a reasonable starting saddle height.
+
+Fast, but doesn't account for individual differences in thigh-to-shin ratio.
+
+### Method 2: inseam formula (LeMond method)
+
+**Saddle height = inseam × 0.883**
+
+- **Measuring inseam**: stand barefoot against a wall, feet about 15 cm (6 in) apart, wedge a book up between your legs until you feel resistance (simulating saddle contact), then measure the vertical distance from the top edge of the book to the floor
+- **Saddle height**: measured from the **bottom bracket center** along the seat tube to the **top of the saddle**
+
+Most references put the multiplier somewhere between 0.88 and 0.885 — the difference is small. This formula gives you a **starting point**, not a final answer.
+
+### Method 3: knee-angle method (the most accurate self-check)
+
+The standard more widely accepted in sports biomechanics: **with the crank at its lowest point, the knee should retain a 25°–35° bend** (the Holmes method).
+
+Check it yourself with a side-view video: ride normally (in your usual shoes, clipped in if using cleats), pull the frame where the pedal is at its lowest point, and measure the angle between thigh and shin.
+
+- Below 25° (leg too straight) → saddle is too high
+- Above 35° (too much bend) → saddle is too low
+
+### Adjustment principle
+
+**Adjust only 2–3 mm at a time, and ride once or twice before deciding whether to adjust further.** Your body needs time to adapt to a saddle height change — a change that's too big at once masks the real problem and raises your injury risk.
+
+Mark the original position with tape or a marker before adjusting, so you can return to it.
+
+## 2. Fore-aft saddle position
+
+Set fore-aft position only after saddle height is dialed in. The reference standard is **KOPS** (Knee Over Pedal Spindle):
+
+Sit in your normal riding position, turn the crank to the **horizontal 3 o'clock position**, and check that a vertical line dropped from the front of your knee passes roughly through the pedal spindle.
+
+- Riders with relatively longer thighs usually need the saddle further back
+- Riders with relatively longer shins usually need it slightly further forward and slightly higher
+
+> KOPS is only a **starting reference**, not a biomechanical law. What ultimately matters is smooth power delivery, even pressure on the sit bones, and arms that don't have to support body weight.
+
+After adjusting fore-aft position, **recheck your saddle height** — sliding the saddle along its rails changes the effective height too.
+
+## 3. The three hand positions
+
+The three hand positions on a road drop bar each have a clearly defined use case — **none is universally better, only better suited to a given situation.**
+
+### 1. The hoods — most versatile
+
+Hands rest on top of the brake/shift levers.
+
+- **Advantages**: a balance of aerodynamics and comfort; instant access to brakes and shifting; switching between seated and standing (climbing out of the saddle) doesn't require a hand-position change
+- **Best for**: flat cruising, climbing, most group-riding situations
+- This is the position used most during training and racing, and stays comfortable even on long rides
+
+### 2. The tops — most comfortable
+
+Hands rest on the straight upper section of the bar.
+
+- **Advantages**: hands closest to the body, most upright back position, best comfort
+- **Disadvantages**: **no immediate access to the brakes**, worst aerodynamics, narrower hand spacing reduces control
+- **Best for**: **only situations with minimal need to brake** — gentle climbs, quiet, open roads
+- **Not suited to**: high speed, descents, traffic, group riding
+
+> Be especially careful using the tops in a group. You can't brake instantly, and sudden situations in a group often give you only a second or two to react.
+
+### 3. The drops — best control
+
+Hands grip the lower curved section of the bar.
+
+- **Advantages**: best control and braking power (longer lever for your fingers, more stable grip); low center of gravity, near-horizontal back, best aerodynamics
+- **Disadvantages**: noticeably less comfortable than the other two positions, and with limited flexibility your lower back tires faster
+- **Best for**: sprinting, descending, headwinds, situations demanding maximum braking power
+
+> Worth noting: shape and function vary a lot between drop-bar brands and models — not every bar is designed primarily around hand comfort.
+
+## 4. Shifting fine-tuning
+
+### Barrel adjuster
+
+Road bikes usually have a barrel adjuster **on the derailleur itself** and **at the cable entry near the head tube**, letting you fine-tune cable tension directly.
+
+Typical symptoms and fixes (mechanical shifting):
+
+- **Slow to upshift / won't reach the largest cog (inward)** → tension too low; turn the adjuster counterclockwise (out) to increase tension
+- **Slow to downshift / won't reach the smallest cog (outward)** → tension too high; turn the adjuster clockwise (in) to decrease tension
+- Adjust **a quarter to half turn at a time**, turning the crank as you test each shift
+
+### Limit screws (not recommended for beginners)
+
+The screws marked **H** (High, smallest cog) and **L** (Low, largest cog) on the rear derailleur set the limits of its travel.
+
+The principle: first make sure the chain stays properly contained at both extreme gear combinations — not interfering with shifting, and not derailing (dropping into the spokes or off the edge of the cassette). **Only once that's confirmed** should you restore shift performance through cable tension.
+
+**Getting the limit screws wrong can send the chain into the spokes, potentially destroying the derailleur, hanger, or even the wheel. Not recommended for beginners to adjust themselves — leave it to a shop or an experienced rider.**
+
+### Electronic shifting
+
+Fine-tuning on Di2 / eTap / EPS happens through the **shift lever or an app**, with no cable-tension issue at all. The logic is a fixed positional offset per gear, set directly.
+
+Remember to **check the battery** before you leave — when it runs low, front shifting usually goes first.
+
+## 5. Brake systems
+
+### Common types
+
+- **Rim brakes (calipers)**: the traditional road bike solution. Simple, light, cheap to maintain, easy to service yourself. Downside: noticeably reduced stopping power in the rain, and long descents heat up the rim
+- **Disc brakes**: made up of the lever, a hydraulic hose or cable, the caliper, pads, and a rotor. **Stronger braking power, more linear feel, less degradation in the rain.** Downside: more complex, more expensive, higher maintenance threshold
+- **V-brakes**: mostly seen on city bikes, touring bikes, and flat-bar bikes — essentially unused on drop-bar road bikes
+
+> **Whatever the brake type, the rotor, pads, and rim braking surface must never come into contact with oil.** Contamination causes a sharp drop in braking power that's usually only fixed by replacing the pads.
+
+For specific braking technique (front/rear balance, cornering, rain, heat management on long descents), see → [Cadence, Shifting, and Braking: Three Core Riding Skills](/en/knowledge/training/cadence-shifting-braking)
+
+---
+
+## Next steps
+
+- Riding technique → [Cadence, Shifting, and Braking: Three Core Riding Skills](/en/knowledge/training/cadence-shifting-braking)
+- Pre-ride checks → [Gear List and the ABC Quick Check](/en/knowledge/training/pre-ride-check-abc)

--- a/frontend/src/content/knowledge/training/en/cadence-shifting-braking.md
+++ b/frontend/src/content/knowledge/training/en/cadence-shifting-braking.md
@@ -1,0 +1,168 @@
+---
+slug: cadence-shifting-braking
+category: skills
+title: 'Cadence, Shifting, and Braking: Three Core Riding Skills'
+description: 'Cadence determines how long you can ride. Shifting determines how long your knees hold up. Braking determines whether you make it home safely. The principles, common mistakes, and a self-test you can run to find your own cadence.'
+author: ACC Club
+date: 2026-08-01
+tags:
+  - riding skills
+  - cadence
+  - braking
+  - eaglet program
+cover: /images/media/adventure/rad-race-120-2025/gallery/2025-sonntag.jpg
+---
+
+If you could only give a beginner three pieces of technical advice, these would be it: **ride at a sensible cadence**, **shift at the right moment**, **brake in the right place**.
+
+## 1. Cadence
+
+### Why cadence matters
+
+The same power output can come from two different combinations: "big gear, low cadence" or "small gear, high cadence":
+
+- **Low cadence, high force** → high muscular load, muscle fibers fatigue quickly, high pressure on the knee joints
+- **High cadence, low force** → higher cardiovascular load, but much lower muscular and joint stress
+
+On endurance rides, **muscular fatigue usually becomes the limiting factor before your cardiovascular system does.** That's why raising cadence and lowering the force per pedal stroke noticeably extends how far you can ride. It's also why professional riders tend to spin a relatively high cadence consistently.
+
+### Reference ranges
+
+| Situation | Cadence range |
+| --- | --- |
+| Flat cruising / interval training | **85–100 rpm** |
+| Climbing | **70–85 rpm** |
+| Recovery riding | 80–95 rpm (easy gear) |
+
+On climbs, gradient and gearing limit you and you usually won't hit flat-road cadence — **holding 70–80 rpm is already solid.**
+
+Worth noting: "optimal cadence" varies noticeably between individuals. Trained riders tend to naturally settle somewhere between 85–95 rpm, but that's a range, not a target you need to hit. **Don't sacrifice smoothness chasing a specific number.**
+
+### Judging cadence without a computer
+
+Pay attention to **how stable your body is**:
+
+- Smooth, quick pedaling with no feeling of "pedaling into thin air" or "getting bounced up" → cadence is reasonable
+- Upper body rocking side to side with each pedal stroke, hips bouncing on the saddle → **cadence too high**, beyond your current neuromuscular control
+- Every stroke needs visible effort and your speed lurches → **cadence too low**, time for an easier gear
+
+Cadence training is a **long-term, deliberate process** — the goal is staying stable at a high cadence, becoming one with the bike. Easier said than done — it takes sustained, focused practice.
+
+### Self-test: finding your economical cadence
+
+A comparison test you can run yourself:
+
+1. Find a stretch of road you can ride **continuously for 10 minutes without interruption**, and use the same one every time
+2. **First run**: ride it at 80 rpm, note your time and self-rated fatigue (1–10 scale)
+3. Spin easy for 15–20 minutes
+4. **Second run**: ride it at 95–100 rpm, note time and fatigue again
+5. **Repeat a few days later**, but reverse the order (high cadence first, then low) to cancel out any order effect
+6. Compare: **whichever cadence got you there faster with lower perceived fatigue is your economical cadence**
+
+For a finer result, break the cadences down further: 80 / 85 / 90 / 95 / 100 / 110 rpm. If you end up feeling best somewhere in the 85–110 rpm range, that's a good sign — your natural cadence habit is already in an efficient zone.
+
+> A single test is a small sample and the result is only a rough indicator. What matters is watching the **trend**, not chasing a precise number.
+
+## 2. Shifting
+
+### First principle: keep pedaling
+
+**Always keep pedaling while you shift.**
+
+The mechanics: the derailleur only pushes the chain **toward** the new position — what actually pulls it up onto the new cog or ring is the tension you generate by pedaling. Shift while coasting and the chain won't move; then, the instant you pedal again, it slams into place with a clunk, which damages the chain, cassette, and chainrings over time.
+
+But also **don't shift at peak pedaling force** (like when you're out of the saddle on a climb). The ideal is: **keep the cranks turning, but briefly ease off the force.**
+
+### Second principle: shift early, shift ahead
+
+**Anticipate your shifts, and shift before you need to.**
+
+Climbing especially: if you hit a rise in a gear that's too big, you'll often bog down after two or three strokes. At that point the chain tension is very high, and shifting to an easier gear tends to produce a loud clunk. Once or twice does no lasting harm, but doing it repeatedly causes irreversible wear to the chain, derailleur, cassette, and chainrings.
+
+**Do it right by shifting into the correct gear before the gradient actually increases.** Before a climb, the front chainring is usually shifted to the small ring ahead of time.
+
+### Judging the right moment to shift
+
+As gradient increases, it gets progressively harder to hold your current cadence. The right time to shift: **the moment you feel your speed about to drop and cadence starting to become hard to hold** — not once you're already stalled out.
+
+- **Shifting too early** → sudden loss of resistance, pedaling into thin air, an abrupt drop in speed; the support your knee was getting suddenly disappears, which is also an injury risk
+- **Shifting too late** → resistance keeps climbing, cadence becomes impossible to hold, and you end up rocking your body or forcing much more effort just to barely maintain cadence — **excessive load on the knee joint**
+
+Neither is good. Shifting too early and too late can both lead to joint injury.
+
+### Coordinating front and rear shifts
+
+- **Small changes in terrain** (gentle rises, rolling road) → fine-tune with the rear derailleur alone
+- **Large changes in terrain** (long climb, long descent) → adjust the front derailleur first, then fine-tune the rear
+
+### Avoiding cross-chaining
+
+**Big ring + largest cog** or **small ring + smallest cog** puts the chain at a severe angle, causing noise, faster wear, reduced drivetrain efficiency, and in extreme cases a dropped chain.
+
+If you find yourself needing those combinations, it's a sign you should switch the front chainring instead.
+
+> Terrain on a long ride changes constantly — there's no such thing as a "one gear fits all" setup. **Shift often, shift promptly.**
+
+## 3. Braking
+
+### Front or rear brake?
+
+Braking shifts your weight forward, **increasing grip at the front wheel and reducing it at the rear.** As a result:
+
+- The **front brake** provides most of your stopping power (roughly 70%), but if your weight shifts too far forward it can lift the rear wheel off the ground
+- The **rear brake** is weaker and better for fine speed adjustments; pulling it too hard locks the rear wheel, causing it to swing sideways and destabilizing your balance
+
+**As a rule, don't rely on either brake alone.** The right approach is to **apply both together**, starting with light, even, progressive taps; if you need to slow further, shift to steady light pressure; if it's still too fast, keep increasing pressure gradually.
+
+**Never grab the brakes suddenly at full force.**
+
+When you need to brake hard, **actively shift your weight back** (lift your hips slightly off the saddle, toward the rear), which lets you use more front-brake power without going over the bars.
+
+### Cornering: finish slowing before the corner
+
+The single most important rule: **slow to your cornering speed before the corner, not while you're in it.**
+
+The mechanics: a tire's grip is finite, and it has to cover both **steering** and **braking** at the same time. Grip at the front wheel changes in complicated ways mid-corner — an unexpected lockup at either wheel causes an immediate crash.
+
+So:
+
+- **Finish slowing before entering the corner**
+- If you absolutely must brake mid-corner, keep it even front-to-back and extremely gentle
+- **Avoid hard braking mid-corner**
+- Take an **outside–inside–outside** line, hugging the apex on the inside, which lets you carry a larger turning radius
+- Keep the inside pedal **up**, to avoid clipping the ground
+
+### Different scenarios
+
+**Rain**:
+
+- Rim brakes form a film of water on the braking surface, so the pad can't generate friction right away. **Tap the brake lightly while riding** to let the pad wipe the water film off the surface — braking performance recovers noticeably after
+- Disc brakes are affected much less by rain, though they still show a brief initial lag
+- Overall, **plan for roughly double the stopping distance** compared to dry roads
+
+**Rough surfaces**:
+
+- Ride the **drops**, gripping the bar with your fingers wrapped fully around it so you're less likely to lose your grip over bumps
+- Lift your hips slightly off the saddle, keep your arms and legs slightly bent, and let your body absorb shock to reduce impact
+
+**Tight corners on steep sections**:
+
+- Ride the **drops**, shift your weight back
+- Watch that the inside pedal doesn't clip the ground
+
+**Long descents**:
+
+- Brake **intermittently**, don't hold the brakes continuously
+- Rim brakes: prolonged friction between pad and an aluminum or carbon rim generates heat, which can cause a blowout or damage a carbon rim. Find a spot to stop and let them cool fully
+- Disc brakes: also heat up and lose power (fading) — let the rotor cool before continuing
+
+### Preparing before the ride
+
+If you know a long descent is part of your route, **check your brake cables or hoses for damage before you leave**, and test the brake system on a nearby short up/down slope to check the braking surfaces for anything unusual, contamination, or scoring.
+
+---
+
+## Next steps
+
+- Bike setup → [Saddle Height, Hand Position, and Shifting](/en/knowledge/training/bike-setup-basics)
+- Group riding etiquette → [Group Riding Etiquette: Hand Signals, Formation, and Following Distance](/en/knowledge/training/acc-group-riding-rules)

--- a/frontend/src/content/knowledge/training/en/german-cycling-traffic-rules.md
+++ b/frontend/src/content/knowledge/training/en/german-cycling-traffic-rules.md
@@ -1,0 +1,131 @@
+---
+slug: german-cycling-traffic-rules
+category: safety
+title: 'German Traffic Rules for Cyclists: A Beginner''s Guide'
+description: In Germany, a bicycle is a full-fledged vehicle — with clear rights and equally clear obligations. A practical summary of the StVO provisions that matter most to cyclists, from when a bike lane is mandatory to the legal definition of a group ride.
+author: ACC Club
+date: 2026-08-04
+featured: true
+tags:
+  - safety
+  - traffic rules
+  - Germany
+  - eaglet program
+cover: /images/shared/stock/munich-cycling.jpg
+---
+
+In Germany, a bicycle is legally a **vehicle (Fahrzeug)** — not a toy, and not an extension of pedestrian traffic. That means on any road except the Autobahn and Kraftfahrstraße (motorway-grade roads), cyclists have the same right to use the main carriageway (Fahrbahn) as cars — and are bound by the same rules.
+
+This article is based on the German road traffic regulations (Straßenverkehrs-Ordnung, StVO). **Laws get amended and specific stretches of road can carry special signage — always defer to the signs on the ground and the current text of the law.**
+
+## 1. When is a bike lane mandatory?
+
+This is the most common misunderstanding among newcomers. The answer: **only when one of the blue, round mandatory-use signs is posted.**
+
+| Sign | Number | Meaning |
+| --- | --- | --- |
+| Blue circle, white bicycle | **Zeichen 237** | Bike lane, **mandatory use** |
+| Blue circle, bicycle + pedestrian (stacked) | **Zeichen 240** | Shared bike/pedestrian path, **mandatory use** |
+| Blue circle, bicycle + pedestrian (side by side) | **Zeichen 241** | Separated bike/pedestrian path, **mandatory use of the bike side** |
+
+§2(4) StVO states plainly:
+
+> "A duty to use bike lanes in the respective direction of travel exists only where this is ordered by signs 237, 240, or 241."
+
+In other words: **if there's a bike lane next to the road but none of these three blue signs is posted, you're fully within your rights to ride on the main carriageway instead.** A right-side bike lane without one of these signs is classified as "other bike lane" (andere Radwege) — use is optional.
+
+There's also a separate category of prohibition signs (white with a red border) that ban cyclists outright — those must always be obeyed.
+
+> Practical note: even when using the bike lane is optional, judge which option is actually safer in the moment. A narrow bike lane blocked by parked cars with poor visibility at intersections can be riskier than the main road.
+
+## 2. Can you ride two abreast?
+
+**Yes, as long as it doesn't obstruct traffic.**
+
+§2(4) StVO:
+
+> "Cyclists may ride side by side, as long as traffic is not thereby obstructed."
+
+This wording dates to the 2020 amendment — before that, riding two abreast was banned by default with exceptions; now it's allowed by default and prohibited only when it causes an obstruction. The practical test: can traffic behind you still overtake safely while you're riding side by side? On narrow city streets or in heavy traffic, default to single file.
+
+## 3. The legal definition of a group ride
+
+This is the one every group ride needs to get right. §27(1) StVO:
+
+> "More than 15 cyclists may form a closed formation (geschlossener Verband). In that case, they may ride two abreast on the carriageway."
+
+The exact threshold, precisely:
+
+- **16 riders or more** (the law says "more than 15") → qualifies as a Verband, may legally ride two abreast
+- **15 riders or fewer** → does not qualify as a Verband, ordinary rules apply (§2(4): side by side only when it doesn't obstruct traffic)
+
+The legal significance of a Verband: **the entire formation is treated as a single vehicle unit.** If the lead riders cross an intersection on a green light and it turns red before the rest of the group clears it, the remaining riders may still legally proceed — the formation may not be split up mid-crossing. But this only applies if the group is a recognizable, tight, organized unit — a loosely strung-out group spread over several hundred meters does not qualify as a Verband.
+
+> Whether the Verband rule applies depends on the actual headcount on the day, and should be confirmed by the group before setting off. **Don't assume it applies.**
+
+## 4. Intersections and right-of-way
+
+### Right-before-left (Rechts vor Links)
+
+At intersections without priority signs or traffic lights (typical in residential areas and 30 km/h zones), **traffic coming from the right has priority.** This rule applies equally to cyclists — you must yield to traffic on your right, and traffic on your left must yield to you.
+
+Most intersections inside a 30 km/h zone follow right-before-left, **with no signage indicating it at all**. This is the single most common cause of accidents among foreign cyclists: assuming you're on a priority road when, legally, you aren't.
+
+### Traffic lights
+
+§37 StVO:
+
+- If the intersection has a **dedicated cyclist signal**, follow that signal
+- If there's no dedicated cyclist signal, and you're riding on the main carriageway, **follow the vehicle traffic signal**
+- **Pedestrian signals do not apply to cyclists** (unless you're walking your bike, in which case you're legally a pedestrian)
+
+### Two ways to turn left
+
+1. **Direct left turn**: on the carriageway, check over your shoulder in good time, signal with your left arm, merge into the left-turn lane, and turn like a car would. Suits situations where your speed is close to the surrounding traffic and visibility at the intersection is good
+2. **Indirect (two-stage) left turn**: ride straight across the intersection to the waiting area on the right side of the road you're turning onto, rotate 90°, then proceed straight when that direction gets a green light. Some intersections have signage that makes this the required method
+
+For beginners and larger groups, the indirect left turn carries a much larger safety margin.
+
+## 5. Fahrradstraße and Fahrrad-Zone
+
+**Fahrradstraße (bike street, Zeichen 244.1)**:
+
+- Bicycles are the primary traffic on this street, **riding side by side is allowed** without the "no obstruction" restriction
+- Speed limit is **30 km/h**, and motor vehicles may not obstruct or endanger cyclists
+- Motor vehicles are **prohibited by default**, unless an additional sign explicitly permits them (e.g., "Anlieger frei" for residents, "Kfz frei")
+
+**Fahrrad-Zone (bike zone, Zeichen 244.3)**: same rules, but covering an entire area rather than a single street.
+
+## 6. Lights and legally required equipment (StVZO)
+
+You **must** use lights in the dark or in poor visibility. Under §67 StVZO, a bicycle must have:
+
+- A **white front light** and a white front reflector
+- A **red rear light** and a red rear reflector
+- **Two independent brakes**
+- A **bell**
+- Reflectors on the pedals and wheels (reflective strips or reflective tires)
+
+Following a 2017 amendment, **battery-powered lights are legal** — a hub dynamo is no longer required. However, flashing front lights are not compliant in Germany — the front light must be steady.
+
+## 7. Alcohol
+
+Cyclists are covered by the same drink-driving thresholds as motor vehicle drivers:
+
+- **1.6 ‰ or above**: absolute unfitness to ride, a criminal offense, and can lead to loss of your **car** driving license
+- **0.3 ‰ or above**, combined with erratic riding or involvement in an accident: already grounds for criminal liability
+
+Worth thinking twice about before riding home from the beer garden.
+
+---
+
+## Sources
+
+- [Full text of the StVO (gesetze-im-internet.de)](https://www.gesetze-im-internet.de/stvo_2013/)
+- [StVO §2 — Use of the road](https://www.gesetze-im-internet.de/stvo_2013/__2.html)
+- [StVO §27 — Closed formations](https://www.gesetze-im-internet.de/stvo_2013/__27.html)
+
+## Next steps
+
+- Pre-ride checks → [Gear List and the ABC Quick Check](/en/knowledge/training/pre-ride-check-abc)
+- Group riding etiquette → [Group Riding Etiquette: Hand Signals, Formation, and Following Distance](/en/knowledge/training/acc-group-riding-rules)

--- a/frontend/src/content/knowledge/training/en/pre-ride-check-abc.md
+++ b/frontend/src/content/knowledge/training/en/pre-ride-check-abc.md
@@ -1,0 +1,103 @@
+---
+slug: pre-ride-check-abc
+category: safety
+title: 'Pre-Ride Checks: Gear List and the ABC Quick Check'
+description: Spend three minutes before every ride on the ABC Quick Check and you'll catch most mechanical failures and flats before they happen. Includes a full gear and toolkit checklist.
+author: ACC Club
+date: 2026-08-05
+featured: true
+tags:
+  - safety
+  - gear
+  - eaglet program
+cover: /images/shared/stock/canyon-road-bike.webp
+---
+
+The most common thing that cuts a ride short isn't someone running out of energy — it's a problem that could have been caught three minutes before departure: low tire pressure, worn-down brake pads, a loose quick release.
+
+The routine below works whether you're riding solo or in a group, and once you're used to it, it takes about three minutes.
+
+## 1. Personal gear
+
+| Gear | Requirement | Notes |
+| --- | --- | --- |
+| **Helmet** | Required | Not legally mandatory for adults in Germany, but required on most group rides. A helmet is a wear item — after an impact, replace it even if it looks fine on the outside |
+| **Glasses** | Strongly recommended | Blocks wind, bugs, and road debris. Use photochromic lenses or swap clear/tinted depending on weather |
+| **Gloves** | Strongly recommended | Your hands are the instinctive first thing to hit the ground in a crash — gloves noticeably reduce road rash and also absorb vibration |
+| **Cleats + clipless pedals** | Optional | Improves pedaling efficiency, but beginners should practice clipping in and out against a wall or on grass before joining a group ride |
+| **Cycling kit** | Recommended | Padded shorts significantly reduce chafing on long rides; jersey pockets carry snacks better than a backpack |
+
+> Beginner tip: the first time you ride with cleats in a group, let people know beforehand. Stopping, intersections, and starting on a climb are the situations where failing to unclip most often causes a fall.
+
+## 2. The ABC Quick Check (pre-ride check)
+
+An internationally common mnemonic for checking your bike before a ride — takes 30 seconds to 3 minutes.
+
+### A — Air (tire pressure)
+
+Squeezing a tire by hand only tells you "has air" versus "no air" — not whether it's actually enough. **Use a floor pump with a gauge** and check before every ride. Road tires naturally lose air every day, even if you pumped them up yesterday.
+
+Reference starting pressures (rider around 70 kg / 155 lb, clincher tire with inner tube):
+
+| Tire width | Front | Rear |
+| --- | --- | --- |
+| 25c | 6.0–6.5 bar (87–94 psi) | 6.5–7.0 bar (94–101 psi) |
+| 28c | 5.0–5.5 bar (72–80 psi) | 5.5–6.0 bar (80–87 psi) |
+| 32c | 4.0–4.5 bar (58–65 psi) | 4.5–5.0 bar (65–72 psi) |
+
+A few principles:
+
+- **The min/max printed on the tire sidewall is an absolute limit** — no recommended value should exceed it
+- Adjust roughly ±0.3–0.5 bar (5–7 psi) for every 22 lb (10 kg) of body weight difference
+- The rear wheel carries more load, so run it 0.3–0.5 bar (5–7 psi) higher than the front
+- Tubeless tires can run 0.5–1.0 bar (7–15 psi) lower than the table above
+- Lower pressure slightly in rain or on rough surfaces — it improves grip and comfort
+
+Recent real-world testing increasingly shows that on actual road surfaces, overinflating a tire often *reduces* rolling efficiency because of vibration losses. **"Pump it rock-hard for max speed" is outdated advice.**
+
+### B — Brakes
+
+- When you squeeze the brake, it should feel **progressive and firm**, not go all the way to the bar with no bite
+- Rim brakes: check pad thickness and the wear grooves; the pad should sit squarely on the braking surface, not touch the tire sidewall
+- Disc brakes: check pad thickness (replace under 0.5 mm) and spin the wheel to check for continuous rubbing
+- **Rotors and pads must never come into contact with oil.** Contamination causes a sharp drop in braking power that's usually only fixed by replacing the pads
+
+### C — Chain / Cranks (drivetrain)
+
+- Check the chain is clean and quiet — lube it if it sounds dry
+- Front and rear shifting should be smooth, and every gear should engage cleanly
+- Turn the crank and check for play or unusual noise
+
+### Quick — quick release / thru axle
+
+Are the front and rear quick releases or thru axles **fully tightened**? This is the most commonly overlooked item, and the consequences are the most serious. A quick release lever should require noticeable hand force to close, and the closed lever position shouldn't foul the frame or a disc rotor.
+
+### Check — full bike check
+
+Lift the bike and tap it gently on the ground, listening for loose rattles; check that the saddle and stem bolts, computer mount, and lights are all secure.
+
+## 3. Tools to carry
+
+For longer rides, carry these — **and know how to use them**:
+
+- **Spare tube** ×1–2 (valve type and length matched to your wheelset)
+- **Tire levers** ×2
+- **Portable pump or CO₂ cartridges** (CO₂ is fast but single-use — carry at least one pump as backup)
+- **Multi-tool** (with common hex sizes and a T25 Torx)
+- **Quick chain link** (matched to your chain's speed — an 11-speed link doesn't fit a 12-speed chain)
+
+> On a group ride, not everyone needs a full kit, but **everyone should carry a spare tube that fits their own bike** — someone else's tube isn't guaranteed to fit your wheelset.
+
+## 4. Electronics
+
+- **Bike computer / phone**: check battery, import your route in advance
+- **Electronic shifting**: check the battery before you leave. When it runs low, front shifting usually goes first while the rear derailleur keeps working a bit longer
+- **Lights**: worth carrying even for a daytime ride — mountain tunnels, sudden weather changes, or a delayed return can all leave you riding in low light
+
+---
+
+## Next steps
+
+- Traffic rules and right-of-way → [German Traffic Rules for Cyclists: A Beginner's Guide](/en/knowledge/training/german-cycling-traffic-rules)
+- Group riding etiquette → [Group Riding Etiquette: Hand Signals, Formation, and Following Distance](/en/knowledge/training/acc-group-riding-rules)
+- Bike setup → [Bike Setup Basics: Saddle Height, Hand Position, and Shifting](/en/knowledge/training/bike-setup-basics)

--- a/progress.md
+++ b/progress.md
@@ -11,10 +11,15 @@
 
 ## Recent Updates
 
-- [X] **Group Riding Rules Hand Gestures Illustration** (2026-08-05)
-  - [X] Generated vector infographic diagram illustrating key group riding hand signals (停车/STOP, 减速/SLOW DOWN, 坑洞/POTHOLE, 转向/TURN, 变单列/SINGLE FILE).
-  - [X] Placed image asset at `frontend/public/images/knowledge/training/acc-group-riding-hand-signals.png`.
-  - [X] Embedded illustration in `frontend/src/content/knowledge/training/zh/acc-group-riding-rules.md` under `### 常用手势`.
+- [X] **Eaglet Program Content i18n** (2026-08-06) — branch `phase-2/eaglet-i18n`
+  - [X] Added complete German and English versions of all three separately registrable Eaglet Program sessions.
+  - [X] Added complete German and English versions of the five published training articles.
+  - [X] Kept event-to-event and event-to-training links within the selected locale.
+  - [X] Removed stale Chinese ACC-specific wording from two event-page references.
+  - [X] Verified with `npm run check` (0 errors), `npm test` (48 passed), `npm run build`, and local rendered-page checks for de/en training shelves, legal content, event ordering, links, and images.
+
+- [X] **Group Riding Hand-Signal Illustration Withdrawn** (2026-08-05)
+  - [X] Removed the experimental illustration and its article reference after visual review; the published group-riding article remains text-only.
 
 - [X] **North Afterwork Ride Location Display Fix** (2026-06-25)
   - [X] Replaced the raw Google Maps URL in zh/en/de event location metadata with readable meeting-point labels.


### PR DESCRIPTION
## Summary

- add complete German and English versions of all three Eaglet Program sessions
- add complete German and English versions of the five published training articles
- keep event and training cross-links within the selected locale
- fix two stale Chinese references left after the group-riding article was generalized
- update `progress.md` and correct the withdrawn hand-signal illustration status

## Impact

The Eaglet Program event and knowledge content is now available consistently in Chinese, English, and German. The English and German training library pages now show real published content instead of the empty state.

## Validation

- `npm run check`: 0 errors
- `npm test`: 48 passed
- `npm run build`: passed
- local rendered-page checks: de/en training shelves, StVO content, event Hero ordering, localized cross-links, and image loading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added English and German Eaglet Program event pages for three Munich training sessions in August 2026.
  - Added bilingual cycling training guides covering group riding, bike setup, cadence, braking, traffic rules, and pre-ride safety checks.
  - Included schedules, requirements, safety guidance, preparation materials, pricing, and registration details.

- **Documentation**
  - Updated Chinese event wording and removed references to a withdrawn group-riding illustration.
  - Added links between related events and training resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->