### PR TITLE
feat(events): notify ride leaders of new RSVPs

### DIFF
--- a/backend/migrations/011_add_rsvp_registration_alerts.sql
+++ b/backend/migrations/011_add_rsvp_registration_alerts.sql
@@ -1,0 +1,9 @@
+-- Add per-event new-registration alert subscriptions for ride leaders.
+
+ALTER TABLE rsvps
+    ADD COLUMN IF NOT EXISTS receives_registration_alerts BOOLEAN
+    NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_rsvps_registration_alerts
+    ON rsvps(event_id)
+    WHERE receives_registration_alerts = TRUE;

--- a/backend/models.py
+++ b/backend/models.py
@@ -116,6 +116,11 @@ class RSVP(Base):
     privacy_accepted = Column(Boolean, default=False)
     view_token = Column(String(64), nullable=True, index=True)
     checked_in_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    receives_registration_alerts = Column(
+        Boolean,
+        default=False,
+        nullable=False,
+    )
     created_at = Column(
         DateTime(timezone=True), default=_utcnow, index=True,
     )

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -26,6 +26,7 @@ from services.event_counts import (
     get_available_spots,
     sync_event_current_participants,
 )
+from services.registration_alerts import find_event_rsvp_by_email
 from services.ride_leader_credits import (
     get_annual_ride_leader_progress,
     get_annual_ride_leader_summary,
@@ -48,6 +49,7 @@ REQUIRED_SCHEMA_COLUMNS = {
         "view_token",
         "cancel_reason",
         "checked_in_at",
+        "receives_registration_alerts",
     },
     "events": {
         "distance_km",
@@ -257,6 +259,12 @@ def get_event_rsvps(
         .order_by(RSVP.created_at)
         .all()
     )
+    admin_email = _admin.get("email")
+    admin_rsvp = (
+        find_event_rsvp_by_email(db, event_id, admin_email)
+        if isinstance(admin_email, str)
+        else None
+    )
 
     ride_leader_summary = serialize_ride_leader_snapshot(snapshot)
 
@@ -287,6 +295,9 @@ def get_event_rsvps(
                 "notes": r.notes,
                 "created_at": r.created_at.isoformat() if r.created_at else None,
                 "is_ride_leader": r.id in active_leader_ids,
+                "receives_registration_alerts": (
+                    r.receives_registration_alerts
+                ),
                 "ride_leader_credit_km": (
                     float(credit_map[r.id].credit_km)
                     if r.id in credit_map else None
@@ -294,6 +305,13 @@ def get_event_rsvps(
             }
             for r in rsvps
         ],
+        "registration_alerts": {
+            "eligible": admin_rsvp is not None,
+            "subscribed": bool(
+                admin_rsvp and admin_rsvp.receives_registration_alerts
+            ),
+            "leader_name": admin_rsvp.name if admin_rsvp else None,
+        },
         "summary": {
             "total": len(rsvps),
             "confirmed": len([r for r in rsvps if r.status == "confirmed"]),
@@ -305,6 +323,107 @@ def get_event_rsvps(
             ]),
             **ride_leader_summary,
         },
+    }
+
+
+# Ride leader registration alerts
+
+@router.post(
+    "/api/admin/events/{event_id}/registration-alerts/claim",
+)
+def claim_registration_alerts(
+    event_id: int,
+    db: Session = Depends(get_db),
+    current_admin: dict = Depends(get_current_admin),
+) -> dict:
+    """Subscribe the logged-in ride leader to new RSVP alerts."""
+    event = db.query(Event).filter(Event.id == event_id).one_or_none()
+    if event is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error_code": "EVENT_NOT_FOUND",
+                "message": "Event not found",
+            },
+        )
+
+    admin_email = current_admin.get("email")
+    if not isinstance(admin_email, str):
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "error_code": "ADMIN_EMAIL_REQUIRED",
+                "message": "Dashboard session email is required",
+            },
+        )
+
+    leader_rsvp = find_event_rsvp_by_email(db, event_id, admin_email)
+    if leader_rsvp is None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_code": "RIDE_LEADER_RSVP_REQUIRED",
+                "message": (
+                    "Register for this event with your dashboard email "
+                    "before claiming alerts"
+                ),
+            },
+        )
+
+    leader_rsvp.receives_registration_alerts = True
+    db.commit()
+    db.refresh(leader_rsvp)
+    return {
+        "active": True,
+        "leader_name": leader_rsvp.name,
+    }
+
+
+@router.post(
+    "/api/admin/events/{event_id}/registration-alerts/release",
+)
+def release_registration_alerts(
+    event_id: int,
+    db: Session = Depends(get_db),
+    current_admin: dict = Depends(get_current_admin),
+) -> dict:
+    """Stop new RSVP alerts for the logged-in ride leader."""
+    event = db.query(Event).filter(Event.id == event_id).one_or_none()
+    if event is None:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error_code": "EVENT_NOT_FOUND",
+                "message": "Event not found",
+            },
+        )
+
+    admin_email = current_admin.get("email")
+    if not isinstance(admin_email, str):
+        raise HTTPException(
+            status_code=401,
+            detail={
+                "error_code": "ADMIN_EMAIL_REQUIRED",
+                "message": "Dashboard session email is required",
+            },
+        )
+
+    leader_rsvp = find_event_rsvp_by_email(db, event_id, admin_email)
+    if leader_rsvp is None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_code": "RIDE_LEADER_RSVP_REQUIRED",
+                "message": "No active RSVP matches your dashboard email",
+            },
+        )
+
+    leader_rsvp.receives_registration_alerts = False
+    db.commit()
+    db.refresh(leader_rsvp)
+    return {
+        "active": False,
+        "leader_name": leader_rsvp.name,
     }
 
 

--- a/backend/routes/rsvp.py
+++ b/backend/routes/rsvp.py
@@ -21,6 +21,7 @@ from services.event_counts import (
     count_confirmed_rsvps,
     sync_event_current_participants,
 )
+from services.registration_alerts import send_registration_alerts
 
 logger = logging.getLogger(__name__)
 
@@ -230,6 +231,25 @@ def create_rsvp(
             view_token=new_rsvp.view_token,
         )
 
+    try:
+        send_registration_alerts(
+            db=db,
+            event_id=event.id,
+            event_title=event.title,
+            event_date=event.event_date,
+            participant_name=rsvp_data.name,
+            participant_email=str(rsvp_data.email),
+            registration_status=rsvp_status,
+            confirmed_count=event.current_participants or 0,
+            max_participants=event.max_participants,
+        )
+    except Exception as email_err:
+        logger.error(
+            "Ride leader registration alerts failed: %s",
+            email_err,
+            exc_info=True,
+        )
+
     return RSVPResponse(
         success=True,
         message=(
@@ -410,6 +430,25 @@ def create_rsvp_v2(
             )
     except Exception as email_err:
         logging.error("Email send failed (RSVP still saved): %s", email_err)
+
+    try:
+        send_registration_alerts(
+            db=db,
+            event_id=event.id,
+            event_title=event.title,
+            event_date=event.event_date,
+            participant_name=data.name,
+            participant_email=str(data.email),
+            registration_status=rsvp_status,
+            confirmed_count=event.current_participants or 0,
+            max_participants=event.max_participants,
+        )
+    except Exception as email_err:
+        logger.error(
+            "Ride leader registration alerts failed: %s",
+            email_err,
+            exc_info=True,
+        )
 
     return RSVPResponse(
         success=True,

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -4,6 +4,7 @@ Phase 4.3.3: Resend integration for event confirmations
 """
 
 import logging
+from html import escape
 from typing import Optional
 from datetime import datetime
 from config import settings
@@ -460,6 +461,92 @@ def send_waitlist_email(
         return resend.Emails.send(params)
     except Exception as e:
         return {"status": "error", "message": str(e)}
+
+
+def send_ride_leader_registration_alert(
+    leader_email: str,
+    leader_name: str,
+    participant_name: str,
+    registration_status: str,
+    event_title: str,
+    event_date: datetime,
+    event_id: int,
+    confirmed_count: int,
+    max_participants: Optional[int],
+) -> dict:
+    """Send a ride leader an operational alert for a new RSVP.
+
+    Args:
+        leader_email: Alert recipient address.
+        leader_name: Alert recipient display name.
+        participant_name: New participant display name.
+        registration_status: Confirmed or waitlist RSVP status.
+        event_title: Event display title.
+        event_date: Event start time.
+        event_id: Event identifier used for the dashboard link.
+        confirmed_count: Current number of confirmed participants.
+        max_participants: Event capacity, or None for unlimited capacity.
+
+    Returns:
+        Resend response, or a skipped/error status dictionary.
+    """
+    if not settings.RESEND_API_KEY:
+        logger.debug(
+            "Skipping ride leader registration alert (no RESEND_API_KEY): %s",
+            leader_email,
+        )
+        return {"status": "skipped", "reason": "no_api_key"}
+
+    frontend_url = settings.PUBLIC_FRONTEND_URL or "https://www.across-cc.de"
+    dashboard_url = f"{frontend_url}/dashboard/events/{event_id}"
+    date_text = event_date.strftime("%Y-%m-%d %H:%M")
+    status_text = escape(registration_status.replace("_", " ").title())
+    capacity_text = (
+        f"{confirmed_count} / {max_participants}"
+        if max_participants is not None
+        else str(confirmed_count)
+    )
+    safe_leader_name = escape(leader_name)
+    safe_participant_name = escape(participant_name)
+    safe_event_title = escape(event_title)
+    subject_event = " ".join(event_title.splitlines()).strip()
+    subject_participant = " ".join(participant_name.splitlines()).strip()
+    subject_status = " ".join(registration_status.splitlines()).strip()
+    subject = (
+        f"New {subject_status} RSVP for {subject_event}: "
+        f"{subject_participant}"
+    )
+    html_body = f"""<div style="font-family:Arial,sans-serif;max-width:600px;">
+<h2 style="color:#C62828;">New Event Registration</h2>
+<p>Hi {safe_leader_name},</p>
+<p><strong>{safe_participant_name}</strong> has registered for an event where
+you receive ride-leader alerts.</p>
+<ul>
+  <li><strong>Event:</strong> {safe_event_title}</li>
+  <li><strong>Date:</strong> {date_text}</li>
+  <li><strong>Registration status:</strong> {status_text}</li>
+  <li><strong>Confirmed riders:</strong> {capacity_text}</li>
+</ul>
+<p><a href="{dashboard_url}">Open the event dashboard</a></p>
+<p>— ACC ClubHub Team</p>
+{_CONTACT["en"]}
+</div>"""
+    params = {
+        "from": "ACC ClubHub <noreply@events.across-cc.de>",
+        "to": [leader_email],
+        "subject": subject,
+        "html": html_body,
+    }
+    try:
+        return resend.Emails.send(params)
+    except Exception as exc:
+        logger.error(
+            "Failed to send ride leader registration alert to %s: %s",
+            leader_email,
+            exc,
+            exc_info=True,
+        )
+        return {"status": "error", "message": str(exc)}
 
 
 def send_slot_claim_confirmation(

--- a/backend/services/registration_alerts.py
+++ b/backend/services/registration_alerts.py
@@ -1,0 +1,80 @@
+"""Ride-leader subscriptions for new event registration alerts."""
+
+from datetime import datetime
+from typing import Optional
+
+from models import RSVP
+from services.email import send_ride_leader_registration_alert
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+
+def find_event_rsvp_by_email(
+    db: Session,
+    event_id: int,
+    email: str,
+) -> Optional[RSVP]:
+    """Return an active RSVP matching a dashboard user's email."""
+    normalized_email = email.strip().lower()
+    return (
+        db.query(RSVP)
+        .filter(
+            RSVP.event_id == event_id,
+            func.lower(RSVP.email) == normalized_email,
+            RSVP.status != "cancelled",
+        )
+        .one_or_none()
+    )
+
+
+def get_registration_alert_recipients(
+    db: Session,
+    event_id: int,
+    participant_email: str,
+) -> list[RSVP]:
+    """Return active alert recipients, excluding the new participant."""
+    normalized_participant_email = participant_email.strip().lower()
+    return (
+        db.query(RSVP)
+        .filter(
+            RSVP.event_id == event_id,
+            RSVP.receives_registration_alerts.is_(True),
+            RSVP.status != "cancelled",
+            func.lower(RSVP.email) != normalized_participant_email,
+        )
+        .order_by(RSVP.id)
+        .all()
+    )
+
+
+def send_registration_alerts(
+    db: Session,
+    *,
+    event_id: int,
+    event_title: str,
+    event_date: datetime,
+    participant_name: str,
+    participant_email: str,
+    registration_status: str,
+    confirmed_count: int,
+    max_participants: Optional[int],
+) -> int:
+    """Send one operational alert to each claimed ride leader."""
+    recipients = get_registration_alert_recipients(
+        db,
+        event_id,
+        participant_email,
+    )
+    for recipient in recipients:
+        send_ride_leader_registration_alert(
+            leader_email=recipient.email,
+            leader_name=recipient.name,
+            participant_name=participant_name,
+            registration_status=registration_status,
+            event_title=event_title,
+            event_date=event_date,
+            event_id=event_id,
+            confirmed_count=confirmed_count,
+            max_participants=max_participants,
+        )
+    return len(recipients)

--- a/backend/tests/test_registration_alerts.py
+++ b/backend/tests/test_registration_alerts.py
@@ -1,0 +1,364 @@
+"""Tests for ride-leader alerts when a new RSVP is created."""
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from app import app
+from fastapi.testclient import TestClient
+from models import RSVP, Event
+from routes.auth import get_current_admin
+from services.email import send_ride_leader_registration_alert
+from services.registration_alerts import (
+    get_registration_alert_recipients,
+    send_registration_alerts,
+)
+from sqlalchemy.orm import Session
+
+
+def _set_admin_email(email: str) -> None:
+    """Use the requested dashboard email for the current test."""
+
+    def override_admin() -> dict[str, str]:
+        return {
+            "admin_id": email,
+            "auth_provider": "email",
+            "email": email,
+        }
+
+    app.dependency_overrides[get_current_admin] = override_admin
+
+
+def _add_rsvp(
+    db: Session,
+    event: Event,
+    *,
+    email: str,
+    name: str,
+    status: str = "confirmed",
+    receives_registration_alerts: bool = False,
+) -> RSVP:
+    """Create an RSVP for registration-alert tests."""
+    rsvp = RSVP(
+        event_id=event.id,
+        email=email,
+        name=name,
+        status=status,
+        privacy_accepted=True,
+        view_token=f"token-{name.lower()}",
+        receives_registration_alerts=receives_registration_alerts,
+    )
+    db.add(rsvp)
+    db.commit()
+    db.refresh(rsvp)
+    return rsvp
+
+
+def _v2_payload(
+    event: Event,
+    *,
+    email: str = "new-rider@example.com",
+    name: str = "New Rider",
+) -> dict[str, Any]:
+    """Return a valid CMS-driven RSVP payload."""
+    return {
+        "email": email,
+        "name": name,
+        "privacy_accepted": True,
+        "event_slug": event.slug,
+        "event_title": event.title,
+        "event_location": event.location or "",
+        "event_date": event.event_date.isoformat(),
+        "event_type": event.event_type,
+        "max_participants": event.max_participants,
+        "lang": "en",
+    }
+
+
+def test_claim_and_release_registration_alerts(
+    client: TestClient,
+    db: Session,
+    sample_event: Event,
+) -> None:
+    """A registered dashboard user can claim and release event alerts."""
+    leader = _add_rsvp(
+        db,
+        sample_event,
+        email="leader@example.com",
+        name="Ride Leader",
+    )
+    _set_admin_email("LEADER@example.com")
+
+    claim_response = client.post(
+        f"/api/admin/events/{sample_event.id}/registration-alerts/claim",
+    )
+
+    assert claim_response.status_code == 200
+    assert claim_response.json() == {
+        "active": True,
+        "leader_name": "Ride Leader",
+    }
+    db.refresh(leader)
+    assert leader.receives_registration_alerts is True
+
+    detail_response = client.get(
+        f"/api/admin/events/{sample_event.id}/rsvps",
+    )
+    assert detail_response.status_code == 200
+    detail = detail_response.json()
+    assert detail["registration_alerts"] == {
+        "eligible": True,
+        "subscribed": True,
+        "leader_name": "Ride Leader",
+    }
+    assert detail["rsvps"][0]["receives_registration_alerts"] is True
+
+    release_response = client.post(
+        f"/api/admin/events/{sample_event.id}/registration-alerts/release",
+    )
+
+    assert release_response.status_code == 200
+    assert release_response.json() == {
+        "active": False,
+        "leader_name": "Ride Leader",
+    }
+    db.refresh(leader)
+    assert leader.receives_registration_alerts is False
+
+
+def test_claim_requires_matching_active_rsvp(
+    client: TestClient,
+    sample_event: Event,
+) -> None:
+    """Dashboard users must first RSVP with the same email address."""
+    _set_admin_email("missing@example.com")
+
+    response = client.post(
+        f"/api/admin/events/{sample_event.id}/registration-alerts/claim",
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["error_code"] == ("RIDE_LEADER_RSVP_REQUIRED")
+
+
+def test_new_rsvp_triggers_alerts_after_commit(
+    client_no_auth: TestClient,
+    db: Session,
+    sample_event: Event,
+    monkeypatch: Any,
+) -> None:
+    """Every active claimed leader receives one alert after commit."""
+    _add_rsvp(
+        db,
+        sample_event,
+        email="leader-one@example.com",
+        name="Leader One",
+        receives_registration_alerts=True,
+    )
+    _add_rsvp(
+        db,
+        sample_event,
+        email="leader-two@example.com",
+        name="Leader Two",
+        receives_registration_alerts=True,
+    )
+    captured: list[dict[str, Any]] = []
+
+    def capture_alerts(**kwargs: Any) -> int:
+        captured.append(kwargs)
+        return 2
+
+    monkeypatch.setattr(
+        "routes.rsvp.send_registration_alerts",
+        capture_alerts,
+    )
+
+    response = client_no_auth.post(
+        "/api/rsvp",
+        json=_v2_payload(sample_event),
+    )
+
+    assert response.status_code == 200
+    assert len(captured) == 1
+    alert = captured[0]
+    assert alert["event_id"] == sample_event.id
+    assert alert["participant_name"] == "New Rider"
+    assert alert["participant_email"] == "new-rider@example.com"
+    assert alert["registration_status"] == "waitlist"
+    assert alert["confirmed_count"] == 2
+    assert alert["max_participants"] == 2
+
+
+def test_alert_service_notifies_each_claimed_leader(
+    db: Session,
+    sample_event: Event,
+) -> None:
+    """The alert service sends one message to every active subscriber."""
+    _add_rsvp(
+        db,
+        sample_event,
+        email="leader-one@example.com",
+        name="Leader One",
+        receives_registration_alerts=True,
+    )
+    _add_rsvp(
+        db,
+        sample_event,
+        email="leader-two@example.com",
+        name="Leader Two",
+        receives_registration_alerts=True,
+    )
+
+    with patch(
+        "services.registration_alerts.send_ride_leader_registration_alert",
+        return_value={"id": "test-id"},
+    ) as mock_send:
+        sent_count = send_registration_alerts(
+            db,
+            event_id=sample_event.id,
+            event_title=sample_event.title,
+            event_date=sample_event.event_date,
+            participant_name="New Rider",
+            participant_email="new-rider@example.com",
+            registration_status="confirmed",
+            confirmed_count=1,
+            max_participants=sample_event.max_participants,
+        )
+
+    assert sent_count == 2
+    assert [call.kwargs["leader_email"] for call in mock_send.call_args_list] == [
+        "leader-one@example.com",
+        "leader-two@example.com",
+    ]
+
+
+def test_registration_alert_failure_does_not_rollback_rsvp(
+    client_no_auth: TestClient,
+    db: Session,
+    sample_event: Event,
+    monkeypatch: Any,
+) -> None:
+    """A failed leader alert remains non-fatal after RSVP commit."""
+
+    def fail_alerts(**_kwargs: Any) -> int:
+        raise RuntimeError("email provider unavailable")
+
+    monkeypatch.setattr(
+        "routes.rsvp.send_registration_alerts",
+        fail_alerts,
+    )
+
+    response = client_no_auth.post(
+        "/api/rsvp",
+        json=_v2_payload(sample_event),
+    )
+
+    assert response.status_code == 200
+    saved = (
+        db.query(RSVP)
+        .filter_by(
+            event_id=sample_event.id,
+            email="new-rider@example.com",
+        )
+        .one()
+    )
+    assert saved.status == "confirmed"
+
+
+def test_alert_recipients_exclude_participant_and_cancelled_leader(
+    db: Session,
+    sample_event: Event,
+) -> None:
+    """Self-alerts and subscriptions on cancelled RSVPs stay inactive."""
+    _add_rsvp(
+        db,
+        sample_event,
+        email="returning@example.com",
+        name="Returning Leader",
+        receives_registration_alerts=True,
+    )
+    active_leader = _add_rsvp(
+        db,
+        sample_event,
+        email="active-leader@example.com",
+        name="Active Leader",
+        receives_registration_alerts=True,
+    )
+    _add_rsvp(
+        db,
+        sample_event,
+        email="cancelled-leader@example.com",
+        name="Cancelled Leader",
+        status="cancelled",
+        receives_registration_alerts=True,
+    )
+
+    recipients = get_registration_alert_recipients(
+        db,
+        sample_event.id,
+        "RETURNING@example.com",
+    )
+
+    assert [recipient.id for recipient in recipients] == [active_leader.id]
+
+
+def test_ride_leader_alert_email_omits_private_rsvp_fields() -> None:
+    """The alert includes operational status but not email or notes."""
+    mock_send = MagicMock(return_value={"id": "test-id"})
+
+    with (
+        patch("resend.Emails.send", mock_send),
+        patch("services.email.settings") as mock_settings,
+    ):
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.PUBLIC_FRONTEND_URL = "https://www.across-cc.de"
+        send_ride_leader_registration_alert(
+            leader_email="leader@example.com",
+            leader_name="Leader One",
+            participant_name="New Rider",
+            registration_status="waitlist",
+            event_title="Tuesday After Work",
+            event_date=datetime(2026, 8, 18, 17, 0, tzinfo=timezone.utc),
+            event_id=42,
+            confirmed_count=15,
+            max_participants=15,
+        )
+
+    params = mock_send.call_args[0][0]
+    assert params["to"] == ["leader@example.com"]
+    assert "New Rider" in params["subject"]
+    assert "waitlist" in params["html"].lower()
+    assert "15 / 15" in params["html"]
+    assert "https://www.across-cc.de/dashboard/events/42" in params["html"]
+    assert "new-rider@example.com" not in params["html"]
+    assert "notes" not in params["html"].lower()
+
+
+def test_ride_leader_alert_email_escapes_untrusted_fields() -> None:
+    """Names and event titles cannot inject markup or subject newlines."""
+    mock_send = MagicMock(return_value={"id": "test-id"})
+
+    with (
+        patch("resend.Emails.send", mock_send),
+        patch("services.email.settings") as mock_settings,
+    ):
+        mock_settings.RESEND_API_KEY = "test-key"
+        mock_settings.PUBLIC_FRONTEND_URL = "https://www.across-cc.de"
+        send_ride_leader_registration_alert(
+            leader_email="leader@example.com",
+            leader_name="Leader <One>",
+            participant_name="New <Rider>",
+            registration_status="confirmed\nInjected",
+            event_title="Tuesday\nAfter <Work>",
+            event_date=datetime(2026, 8, 18, 17, 0, tzinfo=timezone.utc),
+            event_id=42,
+            confirmed_count=1,
+            max_participants=15,
+        )
+
+    params = mock_send.call_args[0][0]
+    assert "\n" not in params["subject"]
+    assert "Leader &lt;One&gt;" in params["html"]
+    assert "New &lt;Rider&gt;" in params["html"]
+    assert "After &lt;Work&gt;" in params["html"]
+    assert "<Rider>" not in params["html"]

--- a/frontend/src/pages/dashboard/api/events/[id]/registration-alerts/claim.ts
+++ b/frontend/src/pages/dashboard/api/events/[id]/registration-alerts/claim.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ params, request }) => {
+    const api_url =
+        import.meta.env.PUBLIC_API_URL ||
+        "https://acc-clubhub-events-ms.vercel.app";
+    const cookie = request.headers.get("cookie") || "";
+    const { id } = params;
+    const upstream = await fetch(
+        `${api_url}/api/admin/events/${id}/registration-alerts/claim`,
+        {
+            method: "POST",
+            headers: { Cookie: cookie },
+        },
+    );
+    const data = await upstream.json();
+
+    return new Response(JSON.stringify(data), {
+        status: upstream.status,
+        headers: { "Content-Type": "application/json" },
+    });
+};

--- a/frontend/src/pages/dashboard/api/events/[id]/registration-alerts/release.ts
+++ b/frontend/src/pages/dashboard/api/events/[id]/registration-alerts/release.ts
@@ -1,0 +1,24 @@
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+export const POST: APIRoute = async ({ params, request }) => {
+    const api_url =
+        import.meta.env.PUBLIC_API_URL ||
+        "https://acc-clubhub-events-ms.vercel.app";
+    const cookie = request.headers.get("cookie") || "";
+    const { id } = params;
+    const upstream = await fetch(
+        `${api_url}/api/admin/events/${id}/registration-alerts/release`,
+        {
+            method: "POST",
+            headers: { Cookie: cookie },
+        },
+    );
+    const data = await upstream.json();
+
+    return new Response(JSON.stringify(data), {
+        status: upstream.status,
+        headers: { "Content-Type": "application/json" },
+    });
+};

--- a/frontend/src/pages/dashboard/events/[id].astro
+++ b/frontend/src/pages/dashboard/events/[id].astro
@@ -51,6 +51,7 @@ if (isLocalPreview) {
         notes: "Needs a stable confirm modal",
         created_at: "2026-04-24T12:00:00.000Z",
         is_ride_leader: true,
+        receives_registration_alerts: true,
         ride_leader_credit_km: 48.5,
       },
       {
@@ -64,6 +65,7 @@ if (isLocalPreview) {
         notes: "",
         created_at: "2026-04-23T12:00:00.000Z",
         is_ride_leader: false,
+        receives_registration_alerts: false,
         ride_leader_credit_km: null,
       },
     ],
@@ -79,6 +81,11 @@ if (isLocalPreview) {
       max_credited_leader_count: 2,
       credit_per_leader_km: 48.5,
       total_credited_km: 48.5,
+    },
+    registration_alerts: {
+      eligible: true,
+      subscribed: true,
+      leader_name: "Preview Confirmed Rider",
     },
   };
 } else {
@@ -99,6 +106,14 @@ if (isLocalPreview) {
     const message = e instanceof Error ? e.message : String(e);
     fetchError = `Failed to fetch RSVPs: ${message}`;
   }
+}
+
+if (eventData && !eventData.registration_alerts) {
+  eventData.registration_alerts = {
+    eligible: false,
+    subscribed: false,
+    leader_name: null,
+  };
 }
 
 function formatDate(dateStr: string | null): string {
@@ -461,6 +476,40 @@ function formatKm(value: number | null | undefined): string {
                 <div><dt>Total Credited</dt><dd>{formatKm(eventData.summary.total_credited_km)}</dd></div>
               </dl>
             </section>
+            <section class="ride-summary-card">
+              <h3>New RSVP Alerts</h3>
+              {eventData.registration_alerts.eligible ? (
+                <>
+                  <p>
+                    {eventData.registration_alerts.subscribed
+                      ? `${eventData.registration_alerts.leader_name} receives an email when someone registers.`
+                      : "Claim alerts to receive an email when someone registers."}
+                  </p>
+                  <button
+                    type="button"
+                    class={`action-btn ${eventData.registration_alerts.subscribed ? "secondary" : ""}`}
+                    id={eventData.registration_alerts.subscribed
+                      ? "release-registration-alerts"
+                      : "claim-registration-alerts"}
+                    aria-label={eventData.registration_alerts.subscribed
+                      ? "Stop new registration alerts for this event"
+                      : "Claim new registration alerts for this event"}
+                  >
+                    {eventData.registration_alerts.subscribed
+                      ? "Stop alerts"
+                      : "Claim alerts"}
+                  </button>
+                </>
+              ) : (
+                <p>
+                  Register for this event with your Dashboard login email
+                  before claiming alerts.
+                </p>
+              )}
+              <p>
+                Alert ownership is separate from post-ride leader credit.
+              </p>
+            </section>
           </div>
 
           <div class="actions">
@@ -518,11 +567,16 @@ function formatKm(value: number | null | undefined): string {
                     </td>
                     <td>
                       <div class="row-state">
-                        {rsvp.is_ride_leader ? (
-                          <span class="badge badge-ride-leader">ride leader</span>
-                        ) : (
-                          <span style="color:#8b949e; font-size:0.8rem;">—</span>
-                        )}
+                      {rsvp.is_ride_leader && (
+                        <span class="badge badge-ride-leader">ride leader</span>
+                      )}
+                      {rsvp.receives_registration_alerts && (
+                        <span class="badge badge-ride-leader">RSVP alerts</span>
+                      )}
+                      {!rsvp.is_ride_leader
+                        && !rsvp.receives_registration_alerts && (
+                        <span style="color:#8b949e; font-size:0.8rem;">—</span>
+                      )}
                       </div>
                       {rsvp.ride_leader_credit_km != null && (
                         <div class="leader-credit">{formatKm(rsvp.ride_leader_credit_km)}</div>
@@ -879,6 +933,53 @@ function formatKm(value: number | null | undefined): string {
         btn.addEventListener("click", () => {
           restoreRsvp(btn.dataset.rsvpId, btn.dataset.rsvpName, btn);
         });
+      });
+
+      async function update_registration_alerts(action, button) {
+        const confirmed = await confirmAction({
+          title: action === "claim" ? "Claim new RSVP alerts" : "Stop new RSVP alerts",
+          message: action === "claim"
+            ? "Receive an email whenever another rider registers for this event?"
+            : "Stop receiving new registration emails for this event?",
+          confirmLabel: action === "claim" ? "Claim alerts" : "Stop alerts",
+        });
+        if (!confirmed) return;
+
+        button.disabled = true;
+        try {
+          const response = await fetch(
+            `/dashboard/api/events/${id}/registration-alerts/${action}`,
+            {
+              method: "POST",
+              credentials: "include",
+            },
+          );
+          const data = await response.json();
+          if (!response.ok) {
+            const detail = typeof data.detail === "object"
+              ? data.detail.message
+              : data.detail;
+            throw new Error(detail || `${response.status}`);
+          }
+          window.location.reload();
+        } catch (error) {
+          alert("Failed to update registration alerts: " + error.message);
+          button.disabled = false;
+        }
+      }
+
+      const claim_alerts_button = document.getElementById(
+        "claim-registration-alerts",
+      );
+      claim_alerts_button?.addEventListener("click", () => {
+        update_registration_alerts("claim", claim_alerts_button);
+      });
+
+      const release_alerts_button = document.getElementById(
+        "release-registration-alerts",
+      );
+      release_alerts_button?.addEventListener("click", () => {
+        update_registration_alerts("release", release_alerts_button);
       });
 
       document.getElementById("notify-btn")?.addEventListener("click", async () => {

--- a/progress.md
+++ b/progress.md
@@ -11,6 +11,14 @@
 
 ## Recent Updates
 
+- [X] **Ride Leader New RSVP Alerts** (2026-08-12) — branch `phase-4/ride-leader-rsvp-alerts`
+  - [X] Let a registered Dashboard user claim or stop per-event new-RSVP alerts when the login email matches an active RSVP.
+  - [X] Notify every claimed leader after a confirmed or waitlist RSVP commits, while excluding the new participant and cancelled recipients.
+  - [X] Keep participant email and notes out of the alert email; include event details, registration status, confirmed capacity, and a Dashboard link.
+  - [X] Added migration `011_add_rsvp_registration_alerts.sql` and schema-health coverage for the RSVP alert subscription flag.
+  - [X] Verified 8 focused backend tests, `npm run check` (0 errors), `npm run test` (48 passed), `npm run build`, Ruff on new Python files, and a local Dashboard preview (HTTP 200 plus screenshot review).
+  - [X] Full backend suite reached 143 passed with one existing historical-alias assertion failure reproduced unchanged on a clean `master` archive.
+
 - [X] **Afterwork Ride Leader WeChat QR Update** (2026-08-12)
   - [X] Replaced the expiring North and South Afterwork group QR codes with the personal WeChat QR codes for ride leaders Dashu (大树) and Ronnie, respectively.
   - [X] Updated zh/en/de event copy to tell participants to add the relevant ride leader, who will invite them to the event group.


### PR DESCRIPTION
## Summary

- let a registered Dashboard user claim or stop per-event new-RSVP alerts when their login email matches an active RSVP
- email every claimed ride leader after a confirmed or waitlist registration commits
- exclude the registering participant and cancelled recipients
- keep participant email and notes out of the alert; include event details, status, capacity, and a Dashboard link
- add migration `011_add_rsvp_registration_alerts.sql` and Dashboard claim/release proxies

## Why

Ride leaders currently need to keep reopening the admin Dashboard to see whether new riders have registered. This provides an opt-in operational email after each new RSVP without coupling alert ownership to post-ride leader credit.

## Validation

- focused backend tests: 8 passed
- frontend unit tests: 48 passed
- `npm run check`: 0 errors
- `npm run build`: passed
- Ruff checks on new Python files: passed
- local Dashboard preview: HTTP 200 and screenshot reviewed
- full backend suite: 143 passed, with one pre-existing historical-alias assertion failure reproduced unchanged on a clean `master` archive

## Deployment note

Apply `backend/migrations/011_add_rsvp_registration_alerts.sql` before deploying the backend code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ride leaders can claim or stop receiving new RSVP email alerts for an event.
  * Registration alerts include participant, event, status, and capacity details.
  * Event dashboards show alert ownership and subscription status.
* **Bug Fixes**
  * Alert delivery failures no longer prevent RSVP completion.
  * Alert emails protect private RSVP information and safely format content.
* **Tests**
  * Added coverage for subscriptions, notifications, eligibility, failures, privacy, and multiple recipients.
* **Documentation**
  * Documented the new ride leader RSVP alert functionality and verification results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->