### PR TITLE
fix(events): auto-enable ride leader RSVP alerts

### DIFF
--- a/backend/migrations/012_sync_ride_leader_registration_alerts.sql
+++ b/backend/migrations/012_sync_ride_leader_registration_alerts.sql
@@ -1,0 +1,25 @@
+-- Keep new-registration alerts aligned with active ride-leader assignments.
+
+UPDATE rsvps AS rsvp
+SET receives_registration_alerts = (
+    rsvp.status = 'confirmed'
+    AND rsvp.checked_in_at IS NOT NULL
+    AND EXISTS (
+        SELECT 1
+        FROM event_ride_leader_assignments AS assignment
+        WHERE assignment.event_id = rsvp.event_id
+          AND assignment.rsvp_id = rsvp.id
+          AND assignment.is_active = TRUE
+    )
+)
+WHERE rsvp.receives_registration_alerts IS DISTINCT FROM (
+    rsvp.status = 'confirmed'
+    AND rsvp.checked_in_at IS NOT NULL
+    AND EXISTS (
+        SELECT 1
+        FROM event_ride_leader_assignments AS assignment
+        WHERE assignment.event_id = rsvp.event_id
+          AND assignment.rsvp_id = rsvp.id
+          AND assignment.is_active = TRUE
+    )
+);

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -26,7 +26,7 @@ from services.event_counts import (
     get_available_spots,
     sync_event_current_participants,
 )
-from services.registration_alerts import find_event_rsvp_by_email
+from services.registration_alerts import find_active_ride_leader_rsvp_by_email
 from services.ride_leader_credits import (
     get_annual_ride_leader_progress,
     get_annual_ride_leader_summary,
@@ -261,7 +261,7 @@ def get_event_rsvps(
     )
     admin_email = _admin.get("email")
     admin_rsvp = (
-        find_event_rsvp_by_email(db, event_id, admin_email)
+        find_active_ride_leader_rsvp_by_email(db, event_id, admin_email)
         if isinstance(admin_email, str)
         else None
     )
@@ -357,16 +357,17 @@ def claim_registration_alerts(
             },
         )
 
-    leader_rsvp = find_event_rsvp_by_email(db, event_id, admin_email)
+    leader_rsvp = find_active_ride_leader_rsvp_by_email(
+        db,
+        event_id,
+        admin_email,
+    )
     if leader_rsvp is None:
         raise HTTPException(
             status_code=409,
             detail={
-                "error_code": "RIDE_LEADER_RSVP_REQUIRED",
-                "message": (
-                    "Register for this event with your dashboard email "
-                    "before claiming alerts"
-                ),
+                "error_code": "ACTIVE_RIDE_LEADER_REQUIRED",
+                "message": "Only an active ride leader can claim alerts",
             },
         )
 
@@ -408,13 +409,17 @@ def release_registration_alerts(
             },
         )
 
-    leader_rsvp = find_event_rsvp_by_email(db, event_id, admin_email)
+    leader_rsvp = find_active_ride_leader_rsvp_by_email(
+        db,
+        event_id,
+        admin_email,
+    )
     if leader_rsvp is None:
         raise HTTPException(
             status_code=409,
             detail={
-                "error_code": "RIDE_LEADER_RSVP_REQUIRED",
-                "message": "No active RSVP matches your dashboard email",
+                "error_code": "ACTIVE_RIDE_LEADER_REQUIRED",
+                "message": "No active ride leader matches your dashboard email",
             },
         )
 
@@ -538,7 +543,7 @@ def activate_ride_leader(
     db.commit()
     return {
         "success": True,
-        "message": "Ride leader marked",
+        "message": "Ride leader marked and registration alerts enabled",
         "ride_leader_summary": serialize_ride_leader_snapshot(snapshot),
     }
 
@@ -554,7 +559,7 @@ def deactivate_ride_leader(
     db.commit()
     return {
         "success": True,
-        "message": "Ride leader removed",
+        "message": "Ride leader removed and registration alerts stopped",
         "ride_leader_summary": serialize_ride_leader_snapshot(snapshot),
     }
 

--- a/backend/services/registration_alerts.py
+++ b/backend/services/registration_alerts.py
@@ -3,25 +3,32 @@
 from datetime import datetime
 from typing import Optional
 
-from models import RSVP
+from models import RSVP, EventRideLeaderAssignment
 from services.email import send_ride_leader_registration_alert
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 
-def find_event_rsvp_by_email(
+def find_active_ride_leader_rsvp_by_email(
     db: Session,
     event_id: int,
     email: str,
 ) -> Optional[RSVP]:
-    """Return an active RSVP matching a dashboard user's email."""
+    """Return an active ride leader matching a dashboard user's email."""
     normalized_email = email.strip().lower()
     return (
         db.query(RSVP)
+        .join(
+            EventRideLeaderAssignment,
+            EventRideLeaderAssignment.rsvp_id == RSVP.id,
+        )
         .filter(
             RSVP.event_id == event_id,
             func.lower(RSVP.email) == normalized_email,
-            RSVP.status != "cancelled",
+            RSVP.status == "confirmed",
+            RSVP.checked_in_at.is_not(None),
+            EventRideLeaderAssignment.event_id == event_id,
+            EventRideLeaderAssignment.is_active.is_(True),
         )
         .one_or_none()
     )
@@ -36,11 +43,18 @@ def get_registration_alert_recipients(
     normalized_participant_email = participant_email.strip().lower()
     return (
         db.query(RSVP)
+        .join(
+            EventRideLeaderAssignment,
+            EventRideLeaderAssignment.rsvp_id == RSVP.id,
+        )
         .filter(
             RSVP.event_id == event_id,
             RSVP.receives_registration_alerts.is_(True),
-            RSVP.status != "cancelled",
+            RSVP.status == "confirmed",
+            RSVP.checked_in_at.is_not(None),
             func.lower(RSVP.email) != normalized_participant_email,
+            EventRideLeaderAssignment.event_id == event_id,
+            EventRideLeaderAssignment.is_active.is_(True),
         )
         .order_by(RSVP.id)
         .all()

--- a/backend/services/ride_leader_credits.py
+++ b/backend/services/ride_leader_credits.py
@@ -260,6 +260,14 @@ def revoke_invalid_leader_records_for_rsvp(db: Session, event_id: int, rsvp_id: 
         assignment.revoked_at = now
         changed = True
 
+    rsvp = db.query(RSVP).filter(
+        RSVP.event_id == event_id,
+        RSVP.id == rsvp_id,
+    ).first()
+    if rsvp is not None and rsvp.receives_registration_alerts:
+        rsvp.receives_registration_alerts = False
+        changed = True
+
     credit = db.query(EventRideLeaderCredit).filter(
         EventRideLeaderCredit.event_id == event_id,
         EventRideLeaderCredit.rsvp_id == rsvp_id,
@@ -287,6 +295,7 @@ def recalculate_event_ride_leader_state(db: Session, event_id: int) -> CreditSna
         else:
             assignment.is_active = False
             assignment.revoked_at = now
+            assignment.rsvp.receives_registration_alerts = False
 
     result = compute_credit_snapshot(
         event.distance_km,
@@ -300,6 +309,7 @@ def recalculate_event_ride_leader_state(db: Session, event_id: int) -> CreditSna
         for assignment in overflow:
             assignment.is_active = False
             assignment.revoked_at = now
+            assignment.rsvp.receives_registration_alerts = False
         result = compute_credit_snapshot(
             event.distance_km,
             checked_in_count,
@@ -383,11 +393,20 @@ def mark_rsvp_as_ride_leader(db: Session, event_id: int, rsvp_id: int) -> Credit
         assignment.is_active = True
         assignment.revoked_at = None
 
+    rsvp.receives_registration_alerts = True
+
     db.flush()
     return recalculate_event_ride_leader_state(db, event_id)
 
 
 def unmark_rsvp_as_ride_leader(db: Session, event_id: int, rsvp_id: int) -> CreditSnapshotResult:
+    rsvp = db.query(RSVP).filter(
+        RSVP.event_id == event_id,
+        RSVP.id == rsvp_id,
+    ).first()
+    if rsvp is not None:
+        rsvp.receives_registration_alerts = False
+
     assignment = db.query(EventRideLeaderAssignment).filter(
         EventRideLeaderAssignment.event_id == event_id,
         EventRideLeaderAssignment.rsvp_id == rsvp_id,

--- a/backend/tests/test_admin_ride_leader.py
+++ b/backend/tests/test_admin_ride_leader.py
@@ -106,6 +106,7 @@ class TestRideLeaderWorkflow:
         snapshot = db.query(EventRideLeaderSnapshot).filter_by(event_id=sample_event.id).first()
 
         assert assignment is not None and assignment.is_active is True
+        assert confirmed_rsvp.receives_registration_alerts is True
         assert credit is not None and credit.is_active is True
         assert float(credit.credit_km) == 48.5
         assert snapshot is not None
@@ -166,6 +167,29 @@ class TestRideLeaderWorkflow:
         assignment = db.query(EventRideLeaderAssignment).first()
         assert assignment is not None
         assert assignment.is_active is False
+        db.refresh(confirmed_rsvp)
+        assert confirmed_rsvp.receives_registration_alerts is False
+
+    def test_undo_check_in_stops_leader_registration_alerts(
+        self,
+        client,
+        db,
+        sample_event,
+        confirmed_rsvp,
+    ):
+        sample_event.distance_km = Decimal("48.50")
+        db.commit()
+        _check_in(client, sample_event.id, confirmed_rsvp.id)
+        _mark_leader(client, sample_event.id, confirmed_rsvp.id)
+
+        response = client.post(
+            f"/api/admin/events/{sample_event.id}/rsvp/check-in/undo",
+            json={"rsvp_id": confirmed_rsvp.id},
+        )
+
+        assert response.status_code == 200
+        db.refresh(confirmed_rsvp)
+        assert confirmed_rsvp.receives_registration_alerts is False
 
     def test_cap_enforcement_works(self, client, db, sample_event, confirmed_rsvp):
         sample_event.distance_km = Decimal("60.00")

--- a/backend/tests/test_registration_alerts.py
+++ b/backend/tests/test_registration_alerts.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from app import app
 from fastapi.testclient import TestClient
-from models import RSVP, Event
+from models import RSVP, Event, EventRideLeaderAssignment
 from routes.auth import get_current_admin
 from services.email import send_ride_leader_registration_alert
 from services.registration_alerts import (
@@ -75,18 +75,32 @@ def _v2_payload(
     }
 
 
+def _mark_active_leader(db: Session, rsvp: RSVP) -> None:
+    """Create an active ride-leader assignment for an RSVP."""
+    rsvp.checked_in_at = datetime.now(timezone.utc)
+    db.add(
+        EventRideLeaderAssignment(
+            event_id=rsvp.event_id,
+            rsvp_id=rsvp.id,
+            is_active=True,
+        ),
+    )
+    db.commit()
+
+
 def test_claim_and_release_registration_alerts(
     client: TestClient,
     db: Session,
     sample_event: Event,
 ) -> None:
-    """A registered dashboard user can claim and release event alerts."""
+    """An active ride leader can claim and release event alerts."""
     leader = _add_rsvp(
         db,
         sample_event,
         email="leader@example.com",
         name="Ride Leader",
     )
+    _mark_active_leader(db, leader)
     _set_admin_email("LEADER@example.com")
 
     claim_response = client.post(
@@ -138,7 +152,29 @@ def test_claim_requires_matching_active_rsvp(
     )
 
     assert response.status_code == 409
-    assert response.json()["detail"]["error_code"] == ("RIDE_LEADER_RSVP_REQUIRED")
+    assert response.json()["detail"]["error_code"] == ("ACTIVE_RIDE_LEADER_REQUIRED")
+
+
+def test_claim_requires_active_ride_leader_assignment(
+    client: TestClient,
+    db: Session,
+    sample_event: Event,
+) -> None:
+    """A matching RSVP alone cannot claim ride-leader notifications."""
+    _add_rsvp(
+        db,
+        sample_event,
+        email="rider@example.com",
+        name="Regular Rider",
+    )
+    _set_admin_email("rider@example.com")
+
+    response = client.post(
+        f"/api/admin/events/{sample_event.id}/registration-alerts/claim",
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["error_code"] == ("ACTIVE_RIDE_LEADER_REQUIRED")
 
 
 def test_new_rsvp_triggers_alerts_after_commit(
@@ -148,20 +184,22 @@ def test_new_rsvp_triggers_alerts_after_commit(
     monkeypatch: Any,
 ) -> None:
     """Every active claimed leader receives one alert after commit."""
-    _add_rsvp(
+    leader_one = _add_rsvp(
         db,
         sample_event,
         email="leader-one@example.com",
         name="Leader One",
         receives_registration_alerts=True,
     )
-    _add_rsvp(
+    leader_two = _add_rsvp(
         db,
         sample_event,
         email="leader-two@example.com",
         name="Leader Two",
         receives_registration_alerts=True,
     )
+    _mark_active_leader(db, leader_one)
+    _mark_active_leader(db, leader_two)
     captured: list[dict[str, Any]] = []
 
     def capture_alerts(**kwargs: Any) -> int:
@@ -194,20 +232,22 @@ def test_alert_service_notifies_each_claimed_leader(
     sample_event: Event,
 ) -> None:
     """The alert service sends one message to every active subscriber."""
-    _add_rsvp(
+    leader_one = _add_rsvp(
         db,
         sample_event,
         email="leader-one@example.com",
         name="Leader One",
         receives_registration_alerts=True,
     )
-    _add_rsvp(
+    leader_two = _add_rsvp(
         db,
         sample_event,
         email="leader-two@example.com",
         name="Leader Two",
         receives_registration_alerts=True,
     )
+    _mark_active_leader(db, leader_one)
+    _mark_active_leader(db, leader_two)
 
     with patch(
         "services.registration_alerts.send_ride_leader_registration_alert",
@@ -270,7 +310,7 @@ def test_alert_recipients_exclude_participant_and_cancelled_leader(
     sample_event: Event,
 ) -> None:
     """Self-alerts and subscriptions on cancelled RSVPs stay inactive."""
-    _add_rsvp(
+    returning_leader = _add_rsvp(
         db,
         sample_event,
         email="returning@example.com",
@@ -284,7 +324,7 @@ def test_alert_recipients_exclude_participant_and_cancelled_leader(
         name="Active Leader",
         receives_registration_alerts=True,
     )
-    _add_rsvp(
+    cancelled_leader = _add_rsvp(
         db,
         sample_event,
         email="cancelled-leader@example.com",
@@ -292,6 +332,24 @@ def test_alert_recipients_exclude_participant_and_cancelled_leader(
         status="cancelled",
         receives_registration_alerts=True,
     )
+    inactive_leader = _add_rsvp(
+        db,
+        sample_event,
+        email="inactive-leader@example.com",
+        name="Inactive Leader",
+        receives_registration_alerts=True,
+    )
+    _mark_active_leader(db, returning_leader)
+    _mark_active_leader(db, active_leader)
+    _mark_active_leader(db, cancelled_leader)
+    db.add(
+        EventRideLeaderAssignment(
+            event_id=sample_event.id,
+            rsvp_id=inactive_leader.id,
+            is_active=False,
+        ),
+    )
+    db.commit()
 
     recipients = get_registration_alert_recipients(
         db,

--- a/frontend/src/pages/dashboard/events/[id].astro
+++ b/frontend/src/pages/dashboard/events/[id].astro
@@ -483,7 +483,7 @@ function formatKm(value: number | null | undefined): string {
                   <p>
                     {eventData.registration_alerts.subscribed
                       ? `${eventData.registration_alerts.leader_name} receives an email when someone registers.`
-                      : "Claim alerts to receive an email when someone registers."}
+                      : "Ride leaders receive new registration alerts automatically."}
                   </p>
                   <button
                     type="button"
@@ -502,12 +502,12 @@ function formatKm(value: number | null | undefined): string {
                 </>
               ) : (
                 <p>
-                  Register for this event with your Dashboard login email
-                  before claiming alerts.
+                  Mark a checked-in RSVP as ride leader to enable new
+                  registration alerts automatically.
                 </p>
               )}
               <p>
-                Alert ownership is separate from post-ride leader credit.
+                Removing the ride leader also stops their alerts.
               </p>
             </section>
           </div>
@@ -791,7 +791,7 @@ function formatKm(value: number | null | undefined): string {
       async function markRideLeader(rsvpId, rsvpName, btn) {
         const confirmed = await confirmAction({
           title: "Mark ride leader",
-          message: `Credit ${rsvpName} as ride leader for this event?`,
+          message: `Credit ${rsvpName} as ride leader and enable new registration emails?`,
           confirmLabel: "Mark leader",
         });
         if (!confirmed) return;

--- a/progress.md
+++ b/progress.md
@@ -11,6 +11,13 @@
 
 ## Recent Updates
 
+- [X] **Ride Leader RSVP Alert Auto-Subscription Fix** (2026-08-12) — branch `phase-4/ride-leader-alert-autoclaim`
+  - [X] Automatically enable new-RSVP email alerts when a checked-in RSVP is marked as ride leader.
+  - [X] Stop alerts when the leader role or check-in is removed, and require an active leader assignment during recipient selection.
+  - [X] Restricted manual alert claims to active ride leaders and clarified the Dashboard workflow copy.
+  - [X] Added migration `012_sync_ride_leader_registration_alerts.sql` to enable alerts for existing active ride leaders and clear stale subscriptions.
+  - [X] Verified 23 related backend tests, the full backend suite (145 passed plus the known historical-alias baseline failure), Ruff, `npm run test` (48 passed), `npm run check` (0 errors), and `npm run build`.
+
 - [X] **Ride Leader New RSVP Alerts** (2026-08-12) — branch `phase-4/ride-leader-rsvp-alerts`
   - [X] Let a registered Dashboard user claim or stop per-event new-RSVP alerts when the login email matches an active RSVP.
   - [X] Notify every claimed leader after a confirmed or waitlist RSVP commits, while excluding the new participant and cancelled recipients.


### PR DESCRIPTION
## Root cause

Marking a checked-in RSVP as ride leader created an active ride-leader assignment and credit record, but it did not enable the separate `receives_registration_alerts` flag. New-registration delivery filtered only on that flag, so a correctly marked leader could still receive no alert.

## Fix

- automatically enable new-RSVP alerts when an RSVP is marked as ride leader
- automatically stop alerts when the leader role or check-in is removed
- require an active, checked-in, confirmed ride-leader assignment when selecting recipients
- restrict manual alert claims to active ride leaders
- clarify the Dashboard copy so the automatic behavior is visible
- add migration `012_sync_ride_leader_registration_alerts.sql` to backfill current active leaders and clear stale subscriptions

## Validation

- related backend tests: 23 passed
- full backend suite: 145 passed; the single known historical-alias baseline assertion still fails unchanged
- frontend unit tests: 48 passed
- `npm run check`: 0 errors
- `npm run build`: passed
- Ruff checks on changed alert service and tests: passed

## Deployment note

After merging, run `backend/migrations/012_sync_ride_leader_registration_alerts.sql` in Neon. This is required to activate alerts for leaders who were already marked before this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration alerts now automatically activate for confirmed, checked-in ride leaders.
  * Alerts stop when ride-leader status or check-in is removed.
  * Ride-leader actions now clearly indicate when registration emails are enabled or stopped.

* **Bug Fixes**
  * Prevented non-leaders and inactive assignments from claiming or receiving registration alerts.
  * Synchronized existing alert subscriptions with current ride-leader eligibility.

* **Documentation**
  * Updated administrator guidance and confirmation messages for registration alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->