### PR TITLE
feat(events): add Komoot routes to RSVP emails

### DIFF
--- a/backend/routes/rsvp.py
+++ b/backend/routes/rsvp.py
@@ -3,25 +3,27 @@ ACC ClubHub Backend - RSVP API Routes
 Phase 4.3: Email-based event registration (no OAuth required)
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
-from typing import Optional
-from database import get_db
-from models import Event, RSVP, Subscriber
-from pydantic import BaseModel, EmailStr
-from datetime import datetime, timezone
-import secrets
 import logging
+import secrets
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import urlparse
+
+from database import get_db
+from fastapi import APIRouter, Depends, HTTPException, status
+from models import RSVP, Event, Subscriber
+from pydantic import BaseModel, EmailStr, field_validator
 from services.email import (
     send_confirmation_email,
-    send_waitlist_email,
     send_subscription_confirmation_email,
+    send_waitlist_email,
 )
 from services.event_counts import (
     count_confirmed_rsvps,
     sync_event_current_participants,
 )
 from services.registration_alerts import send_registration_alerts
+from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +76,25 @@ class RSVPCreateV2(BaseModel):
     registration_deadline: Optional[datetime] = None
     wechat_qr_code: Optional[str] = None
     distance_km: Optional[float] = None
+    route_komoot_url: Optional[str] = None
+
+    @field_validator("route_komoot_url")
+    @classmethod
+    def validate_route_komoot_url(cls, value: Optional[str]) -> Optional[str]:
+        """Allow only HTTPS links hosted by Komoot."""
+        if not value:
+            return None
+
+        parsed = urlparse(value)
+        hostname = parsed.hostname or ""
+        is_komoot_host = hostname == "komoot.com" or hostname.endswith(
+            ".komoot.com",
+        )
+        if parsed.scheme != "https" or not is_komoot_host:
+            raise ValueError(
+                "route_komoot_url must be an HTTPS URL hosted by Komoot",
+            )
+        return value
 
 
 class SubscribeRequest(BaseModel):
@@ -417,6 +438,7 @@ def create_rsvp_v2(
                 event_slug=event.slug,
                 view_token=new_rsvp.view_token,
                 wechat_qr_code=data.wechat_qr_code,
+                route_komoot_url=data.route_komoot_url,
             )
         else:
             send_waitlist_email(

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -4,11 +4,12 @@ Phase 4.3.3: Resend integration for event confirmations
 """
 
 import logging
+from datetime import datetime
 from html import escape
 from typing import Optional
-from datetime import datetime
-from config import settings
+
 import resend
+from config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,7 @@ def send_confirmation_email(
     event_slug: str = "",
     view_token: str = "",
     wechat_qr_code: Optional[str] = None,
+    route_komoot_url: Optional[str] = None,
 ) -> dict:
     """Send RSVP confirmation email"""
     if not settings.RESEND_API_KEY:
@@ -58,6 +60,17 @@ def send_confirmation_email(
         f'style="width:180px;height:180px;margin-top:8px;border:1px solid #eee;border-radius:4px;" /></p>'
         if qr_url else ""
     )
+    route_labels = {
+        "zh": "查看 Komoot 路线",
+        "en": "View route on Komoot",
+        "de": "Route auf Komoot ansehen",
+    }
+    route_html = (
+        '<p style="margin-top:1.2em;">'
+        f'<a href="{escape(route_komoot_url, quote=True)}">'
+        f'{route_labels.get(lang, route_labels["en"])}</a></p>'
+        if route_komoot_url else ""
+    )
 
     templates = {
         "zh": {
@@ -69,6 +82,7 @@ def send_confirmation_email(
     <li><strong>时间：</strong>{date_str}</li>
     <li><strong>地点：</strong>{event_location or "待定"}</li>
 </ul>
+{route_html}
 {f'<p><a href="{participant_link}">查看参与名单</a></p>' if participant_link else ""}
 {qr_html}
 <p>祝您骑行愉快！</p>
@@ -83,6 +97,7 @@ def send_confirmation_email(
     <li><strong>Date:</strong> {date_str}</li>
     <li><strong>Location:</strong> {event_location or "TBD"}</li>
 </ul>
+{route_html}
 {f'<p><a href="{participant_link}">View participant list</a></p>' if participant_link else ""}
 {qr_html}
 <p>Enjoy your ride!</p>
@@ -97,6 +112,7 @@ def send_confirmation_email(
     <li><strong>Datum:</strong> {date_str}</li>
     <li><strong>Ort:</strong> {event_location or "TBD"}</li>
 </ul>
+{route_html}
 {f'<p><a href="{participant_link}">Teilnehmerliste ansehen</a></p>' if participant_link else ""}
 {qr_html}
 <p>Viel Spaß beim Radfahren!</p>

--- a/backend/tests/test_confirmation_email.py
+++ b/backend/tests/test_confirmation_email.py
@@ -3,11 +3,11 @@ Tests for send_confirmation_email — focuses on QR code URL construction.
 No actual emails are sent (RESEND_API_KEY is empty in test env).
 """
 
-import pytest
-from unittest.mock import patch, MagicMock
 from datetime import datetime, timezone
-from services.email import send_confirmation_email
+from unittest.mock import MagicMock, patch
 
+import pytest
+from services.email import send_confirmation_email
 
 SAMPLE_DATE = datetime(2026, 4, 19, 9, 0, tzinfo=timezone.utc)
 FRONTEND_URL = "https://www.across-cc.de"
@@ -68,3 +68,50 @@ def test_no_qr_code_omits_img_tag():
     )
     assert "WeChat QR Code" not in params["html"]
     assert "<img" not in params["html"]
+
+
+@pytest.mark.parametrize(
+    ("lang", "label"),
+    [
+        ("zh", "查看 Komoot 路线"),
+        ("en", "View route on Komoot"),
+        ("de", "Route auf Komoot ansehen"),
+    ],
+)
+def test_route_link_is_localized_and_html_safe(
+    lang: str,
+    label: str,
+) -> None:
+    """A supplied Komoot route appears as a localized safe link."""
+    route_url = (
+        "https://www.komoot.com/de-de/tour/3200651827"
+        "?share_token=test-token&ref=wtd"
+    )
+
+    params = _capture_email_params(
+        user_email="test@example.com",
+        user_name="Test User",
+        event_title="Test Ride",
+        event_date=SAMPLE_DATE,
+        lang=lang,
+        route_komoot_url=route_url,
+    )
+
+    assert label in params["html"]
+    assert (
+        'href="https://www.komoot.com/de-de/tour/3200651827'
+        '?share_token=test-token&amp;ref=wtd"'
+    ) in params["html"]
+
+
+def test_no_route_omits_komoot_link() -> None:
+    """Confirmation emails without a route omit the Komoot section."""
+    params = _capture_email_params(
+        user_email="test@example.com",
+        user_name="Test User",
+        event_title="Test Ride",
+        event_date=SAMPLE_DATE,
+        route_komoot_url=None,
+    )
+
+    assert "komoot.com" not in params["html"]

--- a/backend/tests/test_rsvp_v2_sync.py
+++ b/backend/tests/test_rsvp_v2_sync.py
@@ -1,6 +1,9 @@
-import pytest
 from datetime import datetime, timezone
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
 from models import Event
+from sqlalchemy.orm import Session
 
 
 def test_create_rsvp_v2_syncs_metadata(client_no_auth, db):
@@ -100,3 +103,54 @@ def test_create_rsvp_v2_does_not_clear_existing_distance(client_no_auth, db):
     db.expire_all()
     updated_event = db.query(Event).filter(Event.slug == slug).first()
     assert float(updated_event.distance_km) == 42.4
+
+
+def test_create_rsvp_v2_passes_route_to_confirmation_email(
+    client_no_auth: TestClient,
+    db: Session,
+) -> None:
+    """The route is forwarded to email without being stored on Event."""
+    route_url = (
+        "https://www.komoot.com/de-de/tour/3200651827"
+        "?share_token=test-token&ref=wtd"
+    )
+    payload = {
+        "email": "route-rider@example.com",
+        "name": "Route Rider",
+        "privacy_accepted": True,
+        "event_slug": "route-email-test",
+        "event_title": "Route Email Test",
+        "event_location": "Munich",
+        "event_date": "2026-09-01T09:00:00.000Z",
+        "route_komoot_url": route_url,
+        "lang": "en",
+    }
+
+    with patch("routes.rsvp.send_confirmation_email") as mock_send:
+        response = client_no_auth.post("/api/rsvp", json=payload)
+
+    assert response.status_code == 200
+    assert mock_send.call_args.kwargs["route_komoot_url"] == route_url
+    event = db.query(Event).filter(Event.slug == "route-email-test").one()
+    assert "route_komoot_url" not in event.__table__.columns
+
+
+def test_create_rsvp_v2_rejects_non_komoot_route(
+    client_no_auth: TestClient,
+) -> None:
+    """The public RSVP endpoint rejects arbitrary email-link domains."""
+    payload = {
+        "email": "route-rider@example.com",
+        "name": "Route Rider",
+        "privacy_accepted": True,
+        "event_slug": "route-email-test",
+        "event_title": "Route Email Test",
+        "event_location": "Munich",
+        "event_date": "2026-09-01T09:00:00.000Z",
+        "route_komoot_url": "https://example.com/phishing",
+        "lang": "en",
+    }
+
+    response = client_no_auth.post("/api/rsvp", json=payload)
+
+    assert response.status_code == 422

--- a/frontend/src/components/EventRegistrationForm.tsx
+++ b/frontend/src/components/EventRegistrationForm.tsx
@@ -14,6 +14,7 @@ interface EventRegistrationFormProps {
     registrationDeadline: string | null;
     wechatQrCode: string | null;
     distanceKm: number | null;
+    routeKomootUrl: string | null;
     isACCOfficialRide: boolean;
     lang: Locale;
     apiUrl: string;
@@ -39,6 +40,7 @@ export function EventRegistrationForm({
     registrationDeadline,
     wechatQrCode,
     distanceKm,
+    routeKomootUrl,
     isACCOfficialRide,
     lang,
     apiUrl,
@@ -110,6 +112,7 @@ export function EventRegistrationForm({
                     registration_deadline: registrationDeadline,
                     wechat_qr_code: wechatQrCode,
                     distance_km: distanceKm,
+                    route_komoot_url: routeKomootUrl,
                 }),
             });
 

--- a/frontend/src/content/events/de/acc-eaglet-basics-2026-08-15.md
+++ b/frontend/src/content/events/de/acc-eaglet-basics-2026-08-15.md
@@ -14,6 +14,7 @@ heroPriority: 1
 status: published
 ACCOfficialRide: true
 distanceKm: 30
+routeKomootUrl: https://www.komoot.com/de-de/tour/3190190865?share_token=axmnC31fAwZrtZF0OaxMDJbysi0KMcgA3sTf4TjYHY0zm8Bf5x&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 ---
 
@@ -34,6 +35,7 @@ Keine Vorkenntnisse im Gruppenfahren nötig — genau das lernst du hier.
 | **Zeit** | 15. August 2026 (**Samstag**) · **Abfahrt 9:30 Uhr** |
 | **Treffpunkt** | **Am Bavariapark 5, 80339 München-Schwanthalerhöhe** |
 | **Distanz / Intensität** | **20–30 km**, entspanntes Tempo, mit Guide während der gesamten Fahrt |
+| **Route** | [Auf Komoot ansehen](https://www.komoot.com/de-de/tour/3190190865?share_token=axmnC31fAwZrtZF0OaxMDJbysi0KMcgA3sTf4TjYHY0zm8Bf5x&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613) |
 | **Kursgebühr** | ACC-Mitglieder **kostenlos** · Nicht-Mitglieder (Studierende) **10 €** · Nicht-Mitglieder (sonstige) **15 €** |
 | **Zu beachten** | Helmpflicht; bitte Wasser und Grundverpflegung mitbringen |
 

--- a/frontend/src/content/events/de/acc-eaglet-groupride-2026-08-22.md
+++ b/frontend/src/content/events/de/acc-eaglet-groupride-2026-08-22.md
@@ -14,6 +14,7 @@ heroPriority: 2
 status: published
 ACCOfficialRide: true
 distanceKm: 60
+routeKomootUrl: https://www.komoot.com/de-de/tour/3200651827?share_token=aClTH3NvAYXHu4tCFlTV6MMX9MplpSWkCJ4fGvjjFPpQnP1W5p&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 ---
 
@@ -34,6 +35,7 @@ Kurs 1 vorher zu absolvieren ist empfohlen, gleichwertige Grundkenntnisse reiche
 | **Zeit** | 22. August 2026 (**Samstag**) · **Abfahrt 9:30 Uhr** |
 | **Treffpunkt** | **Rapha München, Frauenstraße 8, 80469 München** |
 | **Distanz / Intensität** | **40–60 km**, mittleres Tempo, mit Guide während der gesamten Fahrt |
+| **Route** | [Auf Komoot ansehen](https://www.komoot.com/de-de/tour/3200651827?share_token=aClTH3NvAYXHu4tCFlTV6MMX9MplpSWkCJ4fGvjjFPpQnP1W5p&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613) |
 | **Kursgebühr** | ACC-Mitglieder **kostenlos** · Nicht-Mitglieder (Studierende) **10 €** · Nicht-Mitglieder (sonstige) **15 €** |
 | **Zu beachten** | Helmpflicht; bitte Wasser, Verpflegung und grundlegendes Werkzeug mitbringen |
 

--- a/frontend/src/content/events/de/acc-eaglet-longride-2026-08-29.md
+++ b/frontend/src/content/events/de/acc-eaglet-longride-2026-08-29.md
@@ -14,6 +14,7 @@ heroPriority: 3
 status: published
 ACCOfficialRide: true
 distanceKm: 90
+routeKomootUrl: https://www.komoot.com/de-de/tour/3200649987?share_token=akz56AGsKn8m3NddGmgi6h1pXdzVGjGhvpDrxQPREkP8obzmkl&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 ---
 
@@ -34,6 +35,7 @@ Kurs 1 und 2 vorher zu absolvieren ist empfohlen, gleichwertige Gruppenfahrerfah
 | **Zeit** | 29. August 2026 (**Samstag**) · **Abfahrt 9:30 Uhr** |
 | **Treffpunkt** | **Holzkirchen Bahnhof Fahrradabstellanlage, Bahnhofpl. 9, 83607 Holzkirchen** |
 | **Distanz / Intensität** | **60–90 km**, mit langem Anstieg und langer Abfahrt, mit Guide während der gesamten Fahrt |
+| **Route** | [Auf Komoot ansehen](https://www.komoot.com/de-de/tour/3200649987?share_token=akz56AGsKn8m3NddGmgi6h1pXdzVGjGhvpDrxQPREkP8obzmkl&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613) |
 | **Kursgebühr** | ACC-Mitglieder **kostenlos** · Nicht-Mitglieder (Studierende) **10 €** · Nicht-Mitglieder (sonstige) **15 €** |
 | **Zu beachten** | Helmpflicht; bitte ausreichend Wasser und Verpflegung, Ersatzschlauch und Werkzeug mitbringen |
 

--- a/frontend/src/content/events/en/acc-eaglet-basics-2026-08-15.md
+++ b/frontend/src/content/events/en/acc-eaglet-basics-2026-08-15.md
@@ -14,6 +14,7 @@ heroPriority: 1
 status: published
 ACCOfficialRide: true
 distanceKm: 30
+routeKomootUrl: https://www.komoot.com/de-de/tour/3190190865?share_token=axmnC31fAwZrtZF0OaxMDJbysi0KMcgA3sTf4TjYHY0zm8Bf5x&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 ---
 
@@ -34,6 +35,7 @@ No group-riding experience needed — that's exactly what this session teaches.
 | **Time** | August 15, 2026 (**Saturday**) · **departure 9:30 AM** |
 | **Meeting point** | **Am Bavariapark 5, 80339 München-Schwanthalerhöhe** |
 | **Distance / Intensity** | **20–30 km**, easy pace, led by a guide throughout |
+| **Route** | [View on Komoot](https://www.komoot.com/de-de/tour/3190190865?share_token=axmnC31fAwZrtZF0OaxMDJbysi0KMcgA3sTf4TjYHY0zm8Bf5x&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613) |
 | **Course fee** | ACC members **free** · non-member students **10 €** · non-member non-students **15 €** |
 | **Notes** | Helmet required; please bring water and basic snacks |
 

--- a/frontend/src/content/events/en/acc-eaglet-groupride-2026-08-22.md
+++ b/frontend/src/content/events/en/acc-eaglet-groupride-2026-08-22.md
@@ -14,6 +14,7 @@ heroPriority: 2
 status: published
 ACCOfficialRide: true
 distanceKm: 60
+routeKomootUrl: https://www.komoot.com/de-de/tour/3200651827?share_token=aClTH3NvAYXHu4tCFlTV6MMX9MplpSWkCJ4fGvjjFPpQnP1W5p&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 ---
 
@@ -34,6 +35,7 @@ Completing Session 1 first is recommended, but equivalent basic knowledge also w
 | **Time** | August 22, 2026 (**Saturday**) · **departure 9:30 AM** |
 | **Meeting point** | **Rapha München, Frauenstraße 8, 80469 München** |
 | **Distance / Intensity** | **40–60 km**, moderate pace, led by a guide throughout |
+| **Route** | [View on Komoot](https://www.komoot.com/de-de/tour/3200651827?share_token=aClTH3NvAYXHu4tCFlTV6MMX9MplpSWkCJ4fGvjjFPpQnP1W5p&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613) |
 | **Course fee** | ACC members **free** · non-member students **10 €** · non-member non-students **15 €** |
 | **Notes** | Helmet required; please bring water, snacks, and basic tools |
 

--- a/frontend/src/content/events/en/acc-eaglet-longride-2026-08-29.md
+++ b/frontend/src/content/events/en/acc-eaglet-longride-2026-08-29.md
@@ -14,6 +14,7 @@ heroPriority: 3
 status: published
 ACCOfficialRide: true
 distanceKm: 90
+routeKomootUrl: https://www.komoot.com/de-de/tour/3200649987?share_token=akz56AGsKn8m3NddGmgi6h1pXdzVGjGhvpDrxQPREkP8obzmkl&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 ---
 
@@ -34,6 +35,7 @@ Completing Sessions 1 and 2 first is recommended, but equivalent group-riding ex
 | **Time** | August 29, 2026 (**Saturday**) · **departure 9:30 AM** |
 | **Meeting point** | **Holzkirchen Bahnhof Fahrradabstellanlage, Bahnhofpl. 9, 83607 Holzkirchen** |
 | **Distance / Intensity** | **60–90 km**, with a long climb and a long descent, led by a guide throughout |
+| **Route** | [View on Komoot](https://www.komoot.com/de-de/tour/3200649987?share_token=akz56AGsKn8m3NddGmgi6h1pXdzVGjGhvpDrxQPREkP8obzmkl&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613) |
 | **Course fee** | ACC members **free** · non-member students **10 €** · non-member non-students **15 €** |
 | **Notes** | Helmet required; please bring plenty of water and snacks, a spare tube, and basic tools |
 

--- a/frontend/src/content/events/zh/acc-eaglet-basics-2026-08-15.md
+++ b/frontend/src/content/events/zh/acc-eaglet-basics-2026-08-15.md
@@ -14,6 +14,7 @@ heroPriority: 1
 status: published
 ACCOfficialRide: true
 distanceKm: 30
+routeKomootUrl: https://www.komoot.com/de-de/tour/3190190865?share_token=axmnC31fAwZrtZF0OaxMDJbysi0KMcgA3sTf4TjYHY0zm8Bf5x&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 ---
 
@@ -34,6 +35,7 @@ registrationLink: ''
 | **时间** | 2026 年 8 月 15 日（**周六**）**9:30 出发** |
 | **集合地点** | **Am Bavariapark 5, 80339 München-Schwanthalerhöhe** |
 | **距离 / 强度** | **20–30 km**，轻松节奏，全程有领骑带队 |
+| **路线** | [Komoot 查看路线](https://www.komoot.com/de-de/tour/3190190865?share_token=axmnC31fAwZrtZF0OaxMDJbysi0KMcgA3sTf4TjYHY0zm8Bf5x&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613) |
 | **课程费** | ACC 会员**免费** · 非会员学生 **10 €** · 非会员非学生 **15 €** |
 | **注意事项** | 头盔必戴；请携带饮水与基础补给 |
 

--- a/frontend/src/content/events/zh/acc-eaglet-groupride-2026-08-22.md
+++ b/frontend/src/content/events/zh/acc-eaglet-groupride-2026-08-22.md
@@ -14,6 +14,7 @@ heroPriority: 2
 status: published
 ACCOfficialRide: true
 distanceKm: 60
+routeKomootUrl: https://www.komoot.com/de-de/tour/3200651827?share_token=aClTH3NvAYXHu4tCFlTV6MMX9MplpSWkCJ4fGvjjFPpQnP1W5p&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 ---
 
@@ -34,6 +35,7 @@ registrationLink: ''
 | **时间** | 2026 年 8 月 22 日（**周六**）**9:30 出发** |
 | **集合地点** | **Rapha München, Frauenstraße 8, 80469 München** |
 | **距离 / 强度** | **40–60 km**，中等节奏，全程有领骑带队 |
+| **路线** | [Komoot 查看路线](https://www.komoot.com/de-de/tour/3200651827?share_token=aClTH3NvAYXHu4tCFlTV6MMX9MplpSWkCJ4fGvjjFPpQnP1W5p&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613) |
 | **课程费** | ACC 会员**免费** · 非会员学生 **10 €** · 非会员非学生 **15 €** |
 | **注意事项** | 头盔必戴；请携带饮水、补给与基础随车工具 |
 

--- a/frontend/src/content/events/zh/acc-eaglet-longride-2026-08-29.md
+++ b/frontend/src/content/events/zh/acc-eaglet-longride-2026-08-29.md
@@ -14,6 +14,7 @@ heroPriority: 3
 status: published
 ACCOfficialRide: true
 distanceKm: 90
+routeKomootUrl: https://www.komoot.com/de-de/tour/3200649987?share_token=akz56AGsKn8m3NddGmgi6h1pXdzVGjGhvpDrxQPREkP8obzmkl&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 ---
 
@@ -34,6 +35,7 @@ registrationLink: ''
 | **时间** | 2026 年 8 月 29 日（**周六**）**9:30 出发** |
 | **集合地点** | **Holzkirchen Bahnhof Fahrradabstellanlage, Bahnhofpl. 9, 83607 Holzkirchen** |
 | **距离 / 强度** | **60–90 km**，含长爬坡与长下坡，全程有领骑带队 |
+| **路线** | [Komoot 查看路线](https://www.komoot.com/de-de/tour/3200649987?share_token=akz56AGsKn8m3NddGmgi6h1pXdzVGjGhvpDrxQPREkP8obzmkl&ref=wtd&t_s=referral&t_cid=route_share&t_ref_username=2285951965613) |
 | **课程费** | ACC 会员**免费** · 非会员学生 **10 €** · 非会员非学生 **15 €** |
 | **注意事项** | 头盔必戴；请携带充足饮水与补给、备用内胎与随车工具 |
 

--- a/frontend/src/pages/[lang]/events/[slug].astro
+++ b/frontend/src/pages/[lang]/events/[slug].astro
@@ -152,6 +152,7 @@ const isACCOfficialRide = entry.data.ACCOfficialRide === true;
       data-registration-deadline={effectiveDeadline}
       data-wechat-qr-code={entry.data.wechatQrCode ?? ''}
       data-distance-km={entry.data.distanceKm != null ? String(entry.data.distanceKm) : ''}
+      data-route-komoot-url={entry.data.routeKomootUrl ?? ''}
       data-acc-official-ride={isACCOfficialRide ? 'true' : ''}
       data-lang={lang}
       data-api-url={apiUrl}
@@ -184,6 +185,7 @@ const isACCOfficialRide = entry.data.ACCOfficialRide === true;
     const wechatQrCode = container.dataset.wechatQrCode || null;
     const distanceKmRaw = container.dataset.distanceKm;
     const distanceKm = distanceKmRaw ? parseFloat(distanceKmRaw) : null;
+    const routeKomootUrl = container.dataset.routeKomootUrl || null;
     const isACCOfficialRide = container.dataset.accOfficialRide === 'true';
     const lang = (container.dataset.lang ?? 'zh') as Locale;
     const apiUrl = container.dataset.apiUrl ?? '';
@@ -204,6 +206,7 @@ const isACCOfficialRide = entry.data.ACCOfficialRide === true;
         registrationDeadline,
         wechatQrCode,
         distanceKm,
+        routeKomootUrl,
         isACCOfficialRide,
         lang,
         apiUrl,

--- a/progress.md
+++ b/progress.md
@@ -11,6 +11,12 @@
 
 ## Recent Updates
 
+- [X] **Eaglet Program Komoot Routes Restored** (2026-08-15)
+  - [X] Added the confirmed Komoot route for each of the three Eaglet sessions across zh/en/de event metadata.
+  - [X] Used share-token URLs for all three sessions to keep the public route links accessible.
+  - [X] Added localized visible route links to all nine event detail tables.
+  - [X] Verified all nine route fields and links, `npm run check` (0 errors), `npm run test` (48 passed), `npm run build`, and rendered zh/en/de event pages (HTTP 200 with the expected route links).
+
 - [X] **Ride Leader RSVP Alert Auto-Subscription Fix** (2026-08-12) — branch `phase-4/ride-leader-alert-autoclaim`
   - [X] Automatically enable new-RSVP email alerts when a checked-in RSVP is marked as ride leader.
   - [X] Stop alerts when the leader role or check-in is removed, and require an active leader assignment during recipient selection.

--- a/progress.md
+++ b/progress.md
@@ -11,6 +11,12 @@
 
 ## Recent Updates
 
+- [X] **Komoot Routes in RSVP Confirmation Emails** (2026-08-15)
+  - [X] Forwarded optional `routeKomootUrl` metadata through the website RSVP request into confirmation emails without storing it in PostgreSQL.
+  - [X] Added localized Komoot links for zh/en/de emails and omitted the section for events without a route.
+  - [X] Restricted the public RSVP field to HTTPS Komoot URLs and HTML-escaped the rendered link.
+  - [X] Verified 11 focused backend tests, 151 passing full-suite tests plus the known historical-alias baseline failure, frontend `npm run test:all`, and an intercepted browser RSVP containing the exact Session 2 route URL.
+
 - [X] **Eaglet Program Komoot Routes Restored** (2026-08-15)
   - [X] Added the confirmed Komoot route for each of the three Eaglet sessions across zh/en/de event metadata.
   - [X] Used share-token URLs for all three sessions to keep the public route links accessible.


### PR DESCRIPTION
## What changed

- restored the confirmed share-token Komoot routes for all three Eaglet sessions across zh/en/de event content
- forwards optional `routeKomootUrl` metadata through the website RSVP request to the confirmation email
- renders localized Komoot links in zh/en/de confirmation emails and omits the section when no route exists
- validates that submitted route links use HTTPS and a Komoot host, then HTML-escapes the email href
- keeps the route request-scoped: no SQL migration, database column, or persistence change

## Why

Event routes were visible on event pages but unavailable to the backend email renderer. The confirmation email only received persisted event fields, while this feature intentionally does not require the server to keep an authoritative route record.

## User impact

New registrations made from an event page with `routeKomootUrl` receive that route in the confirmation email. Events without a route keep the existing email content.

## Validation

- 11 focused backend tests passed
- full backend suite: 151 passed; the existing historical ride-leader alias baseline remains the sole failure (`2 == 3`)
- frontend `npm run test:all`: Astro check 0 errors, 48 Vitest tests passed, production build succeeded
- intercepted browser RSVP from the Session 2 page contained the exact share-token Komoot URL and did not contact the production API
- `git diff --check` passed
- no files under `backend/migrations/` changed