### PR TITLE
fix(events): update south afterwork ride details

### DIFF
--- a/frontend/src/content/events/de/afterwork-ride-munchen-sud.md
+++ b/frontend/src/content/events/de/afterwork-ride-munchen-sud.md
@@ -1,10 +1,10 @@
 ---
 slug: afterwork-ride-Munich-South
 title: ACC After Work Ride · München Süd
-description: Wöchentliche entspannte Social After-Work-Runde im Münchner Süden, jeden Dienstag mit Treffen um 16:45 Uhr und Abfahrt um 17:00 Uhr ab Liesl-Karlstadt-Straße 1.
-date: 2026-05-05 16:45
+description: Wöchentliche entspannte Social After-Work-Runde im Münchner Süden, jeden Dienstag mit Treffen um 17:50 Uhr und Abfahrt um 18:00 Uhr ab Münchner Tierpark.
+date: 2026-05-05 17:50
 eventType: after-work
-location: Liesl-Karlstadt-Straße 1, 81476 München-Thalkirchen-Obersendling-Forstenried-Fürstenried-Solln
+location: Münchner Tierpark · Tierparkstraße 30, 81543 München
 author: ACC Club
 cover: /images/events/acc-after-work-ride-munchen-sud/cover.jpg
 displaySections:
@@ -12,8 +12,8 @@ displaySections:
   - hero
   - upcoming
 maxParticipants: 15
-distanceKm: 40.1
-routeKomootUrl: https://www.komoot.com/tour/3127845298?share_token=atl7U3hhNsR0TAyf3KugF3R18twquZNnSUuo9RBV4vECDEjaX5
+distanceKm: 42
+routeKomootUrl: https://www.komoot.com/tour/2901905197?ref=itd&share_token=ayPDsqhyXUcwfhGDjb5KFl70WF1pLlaVhmNN0EjYdKG9Q29604&ref=its&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 wechatQrCode: /images/events/acc-after-work-ride-munchen-sud/wechat-qr.png
 status: published
@@ -31,15 +31,15 @@ Komm nach der Arbeit mit auf eine entspannte Runde durch den Münchner Süden.
 
 Diese **After-Work Social Ride** richtet sich an alle, die nach der Arbeit noch locker fahren, frische Luft schnappen und gemeinsam mit ACC eine angenehme Abendrunde drehen möchten. Das Tempo ist freundlich, aber grundlegende Erfahrung auf dem Rennrad wird vorausgesetzt.
 
-Treffpunkt ist um **16:45 Uhr** bei **Liesl-Karlstadt-Straße 1, 81476 München-Thalkirchen-Obersendling-Forstenried-Fürstenried-Solln**, die **pünktliche Abfahrt ist um 17:00 Uhr**. Die Details zur Strecke findest du im Komoot-Link. Die Rückkehr zum Startpunkt ist gegen **19:00 Uhr** geplant.
+Treffpunkt ist um **17:50 Uhr** beim **Münchner Tierpark · Tierparkstraße 30, 81543 München**, die **pünktliche Abfahrt ist um 18:00 Uhr**. Die Details zur Strecke findest du im Komoot-Link. Die Strecke ist ca. **42 km** lang mit ca. **320 hm**; die Rückkehr zum Startpunkt ist gegen **20:00 Uhr** geplant.
 
 ---
 
 |                | Infos |
 | -------------- | ----- |
-| **Zeit**       | Treffen um 16:45 Uhr · Pünktliche Abfahrt um 17:00 Uhr · Rückkehr voraussichtlich gegen 19:00 Uhr |
-| **Treffpunkt** | Liesl-Karlstadt-Straße 1, 81476 München-Thalkirchen-Obersendling-Forstenried-Fürstenried-Solln |
-| **Strecke**    | Bitte dem Komoot-Routenlink folgen |
+| **Zeit**       | Treffen um 17:50 Uhr · Pünktliche Abfahrt um 18:00 Uhr · Rückkehr voraussichtlich gegen 20:00 Uhr |
+| **Treffpunkt** | Münchner Tierpark · Tierparkstraße 30, 81543 München |
+| **Strecke**    | Ca. **42 km / 320 hm** · Bitte dem Komoot-Routenlink folgen |
 | **Tempo**      | Entspannte Social Ride; grundlegende Erfahrung auf dem Rennrad wird vorausgesetzt |
 | **Radtyp**     | Rennrad oder Gravelbike empfohlen |
 | **Hinweise**   | Bitte Helm und grundlegende Verpflegung mitbringen; bitte prüfe dein Rad vorab; bitte pünktlich sein; entscheide selbst, ob Tempo und Strecke zu dir passen; bei schlechtem Wetter oder wenn sich außer dem Ride Leader weniger als 2 Personen anmelden, wird die Ausfahrt automatisch abgesagt |
@@ -57,7 +57,7 @@ Alle Radsportbegeisterten sind willkommen. Wenn du dich mit dem angegebenen Temp
 
 ### Logistics
 
-Die Runde endet voraussichtlich gegen **19:00 Uhr wieder am Startpunkt** und eignet sich damit gut für eine Feierabend-Ausfahrt unter der Woche.
+Die Runde endet voraussichtlich gegen **20:00 Uhr wieder am Startpunkt** und eignet sich damit gut für eine Feierabend-Ausfahrt unter der Woche.
 
 ---
 
@@ -80,6 +80,6 @@ Das Hinzufügen der Ride-Leitung bzw. der Beitritt zur Event-Gruppe dient nur de
 
 ### Streckenübersicht
 
-- **Komoot-Route:** [Route ansehen](https://www.komoot.com/tour/3127845298?share_token=atl7U3hhNsR0TAyf3KugF3R18twquZNnSUuo9RBV4vECDEjaX5)
+- **Komoot-Route:** [Route ansehen](https://www.komoot.com/tour/2901905197?ref=itd&share_token=ayPDsqhyXUcwfhGDjb5KFl70WF1pLlaVhmNN0EjYdKG9Q29604&ref=its&t_s=referral&t_cid=route_share&t_ref_username=2285951965613)
 
-<iframe src="https://www.komoot.com/tour/3127845298/embed?profile=1&share_token=atl7U3hhNsR0TAyf3KugF3R18twquZNnSUuo9RBV4vECDEjaX5" width="100%" height="700" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://www.komoot.com/tour/2901905197/embed?profile=1&share_token=ayPDsqhyXUcwfhGDjb5KFl70WF1pLlaVhmNN0EjYdKG9Q29604" width="100%" height="700" frameborder="0" scrolling="no"></iframe>

--- a/frontend/src/content/events/en/afterwork-ride-munchen-sud.md
+++ b/frontend/src/content/events/en/afterwork-ride-munchen-sud.md
@@ -1,10 +1,10 @@
 ---
 slug: afterwork-ride-Munich-South
 title: ACC After Work Ride · München Süd
-description: Weekly relaxed social after-work ride every Tuesday with meet-up at 16:45 and rollout at 17:00, starting from Liesl-Karlstadt-Straße 1 in München Süd.
-date: 2026-05-05 16:45
+description: Weekly relaxed social after-work ride every Tuesday with meet-up at 17:50 and rollout at 18:00, starting from Munich Zoo in München Süd.
+date: 2026-05-05 17:50
 eventType: after-work
-location: Liesl-Karlstadt-Straße 1, 81476 München-Thalkirchen-Obersendling-Forstenried-Fürstenried-Solln
+location: Munich Zoo · Tierparkstraße 30, 81543 München
 author: ACC Club
 cover: /images/events/acc-after-work-ride-munchen-sud/cover.jpg
 displaySections:
@@ -12,8 +12,8 @@ displaySections:
   - hero
   - upcoming
 maxParticipants: 15
-distanceKm: 40.1
-routeKomootUrl: https://www.komoot.com/tour/3127845298?share_token=atl7U3hhNsR0TAyf3KugF3R18twquZNnSUuo9RBV4vECDEjaX5
+distanceKm: 42
+routeKomootUrl: https://www.komoot.com/tour/2901905197?ref=itd&share_token=ayPDsqhyXUcwfhGDjb5KFl70WF1pLlaVhmNN0EjYdKG9Q29604&ref=its&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 wechatQrCode: /images/events/acc-after-work-ride-munchen-sud/wechat-qr.png
 status: published
@@ -31,15 +31,15 @@ Join us for a relaxed ride through München Süd after work.
 
 This is an **after-work social ride** for riders who want to get some fresh air, spin their legs after work, and enjoy an easy evening ride with ACC. The pace is friendly, but participants should be comfortable with basic road riding.
 
-We will meet at **16:45** at **Liesl-Karlstadt-Straße 1, 81476 München-Thalkirchen-Obersendling-Forstenried-Fürstenried-Solln**, with a **prompt rollout at 17:00**. Please follow the Komoot link for the route details. We expect to return to the starting point at around **19:00**.
+We will meet at **17:50** at **Munich Zoo · Tierparkstraße 30, 81543 München**, with a **prompt rollout at 18:00**. Please follow the Komoot link for the route details. The route is about **42 km** with about **320 m** of climbing, and we expect to return to the starting point at around **20:00**.
 
 ***
 
 |  | Details |
 | --- | --- |
-| **Time** | Meet-up at 16:45 · Rollout at 17:00 sharp · Expected return around 19:00 |
-| **Meeting point** | Liesl-Karlstadt-Straße 1, 81476 München-Thalkirchen-Obersendling-Forstenried-Fürstenried-Solln |
-| **Route** | Please follow the Komoot route link |
+| **Time** | Meet-up at 17:50 · Rollout at 18:00 sharp · Expected return around 20:00 |
+| **Meeting point** | Munich Zoo · Tierparkstraße 30, 81543 München |
+| **Route** | Approx. **42 km / 320 m climbing** · Please follow the Komoot route link |
 | **Pace** | Relaxed social ride; basic road-riding ability required |
 | **Bike type** | Road bike or gravel bike recommended |
 | **Notes** | Please bring a helmet and basic supplies; make sure your bike is in good condition; please arrive on time; decide based on your own condition whether this pace and route suit you; the ride will be automatically cancelled in case of severe weather or if fewer than 2 participants register, excluding the ride leader |
@@ -57,7 +57,7 @@ All cycling enthusiasts are welcome. If you are comfortable with the expected pa
 
 ### Logistics
 
-The ride is expected to return to the starting point at around **19:00**, which makes it suitable for a weekday evening outing after work.
+The ride is expected to return to the starting point at around **20:00**, which makes it suitable for a weekday evening outing after work.
 
 ***
 
@@ -80,6 +80,6 @@ Adding the ride leader or joining the event group is for ride communication only
 
 ### Route Preview
 
-- **Komoot route:** [View route](https://www.komoot.com/tour/3127845298?share_token=atl7U3hhNsR0TAyf3KugF3R18twquZNnSUuo9RBV4vECDEjaX5)
+- **Komoot route:** [View route](https://www.komoot.com/tour/2901905197?ref=itd&share_token=ayPDsqhyXUcwfhGDjb5KFl70WF1pLlaVhmNN0EjYdKG9Q29604&ref=its&t_s=referral&t_cid=route_share&t_ref_username=2285951965613)
 
-<iframe src="https://www.komoot.com/tour/3127845298/embed?profile=1&share_token=atl7U3hhNsR0TAyf3KugF3R18twquZNnSUuo9RBV4vECDEjaX5" width="100%" height="700" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://www.komoot.com/tour/2901905197/embed?profile=1&share_token=ayPDsqhyXUcwfhGDjb5KFl70WF1pLlaVhmNN0EjYdKG9Q29604" width="100%" height="700" frameborder="0" scrolling="no"></iframe>

--- a/frontend/src/content/events/zh/afterwork-ride-munchen-sud.md
+++ b/frontend/src/content/events/zh/afterwork-ride-munchen-sud.md
@@ -1,10 +1,10 @@
 ---
 slug: afterwork-ride-Munich-South
 title: ACC After Work Ride · München Süd
-description: 每周二下班后 16:45 集合、17:00 从 Liesl-Karlstadt-Straße 1 出发的慕尼黑南区轻松社交骑行。
-date: 2026-05-05 16:45
+description: 每周二下班后 17:50 集合、18:00 从慕尼黑动物园出发的慕尼黑南区轻松社交骑行。
+date: 2026-05-05 17:50
 eventType: after-work
-location: Liesl-Karlstadt-Straße 1, 81476 München-Thalkirchen-Obersendling-Forstenried-Fürstenried-Solln
+location: 慕尼黑动物园 · Tierparkstraße 30, 81543 München
 author: ACC Club
 cover: /images/events/acc-after-work-ride-munchen-sud/cover.jpg
 displaySections:
@@ -12,8 +12,8 @@ displaySections:
   - hero
   - upcoming
 maxParticipants: 15
-distanceKm: 40.1
-routeKomootUrl: https://www.komoot.com/tour/3127845298?share_token=atl7U3hhNsR0TAyf3KugF3R18twquZNnSUuo9RBV4vECDEjaX5
+distanceKm: 42
+routeKomootUrl: https://www.komoot.com/tour/2901905197?ref=itd&share_token=ayPDsqhyXUcwfhGDjb5KFl70WF1pLlaVhmNN0EjYdKG9Q29604&ref=its&t_s=referral&t_cid=route_share&t_ref_username=2285951965613
 registrationLink: ''
 wechatQrCode: /images/events/acc-after-work-ride-munchen-sud/wechat-qr.png
 status: published
@@ -31,15 +31,15 @@ recurring:
 
 这是一场以 **after-work 社交休闲骑** 为主的路线，适合想在工作日傍晚出来透透气、活动一下，也和 ACC 车友一起骑车的人。整体节奏友好，但默认参加者具备基础公路骑行能力。
 
-我们将于 **16:45** 在 **Liesl-Karlstadt-Straße 1, 81476 München-Thalkirchen-Obersendling-Forstenried-Fürstenried-Solln** 集合，**17:00 准时出发**。路线以 Komoot 链接为准，预计 **19:00 左右回到起点**。
+我们将于 **17:50** 在 **慕尼黑动物园 · Tierparkstraße 30, 81543 München** 集合，**18:00 准时出发**。路线以 Komoot 链接为准，全程约 **42 km**，累计爬升约 **320 m**，预计 **20:00 左右回到起点**。
 
 ***
 
 |  | 信息 |
 | --- | --- |
-| **时间** | 16:45 集合，17:00 准时发车，预计 19:00 回到起点 |
-| **集合地点** | Liesl-Karlstadt-Straße 1, 81476 München-Thalkirchen-Obersendling-Forstenried-Fürstenried-Solln |
-| **路线** | 以 Komoot 路线链接为准 |
+| **时间** | 17:50 集合，18:00 准时发车，预计 20:00 回到起点 |
+| **集合地点** | 慕尼黑动物园 · Tierparkstraße 30, 81543 München |
+| **路线** | 约 **42 km / 320 m 爬升**，以 Komoot 路线链接为准 |
 | **强度** | 偏轻松社交骑，但需具备基础骑行能力 |
 | **适合车辆** | 建议使用 road bike 或 gravel bike |
 | **注意事项** | 请自备头盔与基础补给；请确认车辆状态良好；请准时到达，活动将按时出发；请根据自身状态判断是否适合本次配速与路线；如遇恶劣天气，或除领骑外报名人数不足 2 人，活动将自动取消 |
@@ -49,9 +49,9 @@ recurring:
 
 ### 路线预览
 
-- **Komoot 路线**：[查看路线](https://www.komoot.com/tour/3127845298?share_token=atl7U3hhNsR0TAyf3KugF3R18twquZNnSUuo9RBV4vECDEjaX5)
+- **Komoot 路线**：[查看路线](https://www.komoot.com/tour/2901905197?ref=itd&share_token=ayPDsqhyXUcwfhGDjb5KFl70WF1pLlaVhmNN0EjYdKG9Q29604&ref=its&t_s=referral&t_cid=route_share&t_ref_username=2285951965613)
 
-<iframe src="https://www.komoot.com/tour/3127845298/embed?profile=1&share_token=atl7U3hhNsR0TAyf3KugF3R18twquZNnSUuo9RBV4vECDEjaX5" width="100%" height="700" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://www.komoot.com/tour/2901905197/embed?profile=1&share_token=ayPDsqhyXUcwfhGDjb5KFl70WF1pLlaVhmNN0EjYdKG9Q29604" width="100%" height="700" frameborder="0" scrolling="no"></iframe>
 
 ### 活动说明
 
@@ -64,7 +64,7 @@ recurring:
 
 ### 返程 / Logistics
 
-本次路线预计于 **19:00 左右回到起点**，结束位置与集合点一致，适合下班后参与并在当天晚间返回。
+本次路线预计于 **20:00 左右回到起点**，结束位置与集合点一致，适合下班后参与并在当天晚间返回。
 
 ***
 


### PR DESCRIPTION
## Summary
- update the South Afterwork recurring ride start time to 17:50 meetup / 18:00 rollout
- change the start location to Munich Zoo / Tierparkstrasse 30
- replace the Komoot route with tour 2901905197 and update distance/elevation to 42 km / 320 m across zh/en/de

## Checks
- publish scope guard passed for the three event markdown files
- git diff --check passed
- confirmed old time/location/route values are absent from the three South Afterwork files
- Astro/Vitest full checks not run in the clean worktree because dependencies are not installed there; reusing the dirty worktree node_modules caused Vite/Astro cache path issues