### PR TITLE
feat(events): add cancellation notifications

### DIFF
--- a/backend/migrations/013_add_event_cancellation.sql
+++ b/backend/migrations/013_add_event_cancellation.sql
@@ -1,0 +1,28 @@
+-- Store operational cancellation state separately from RSVP cancellations.
+
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS cancellation_reason VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS cancelled_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE events
+    DROP CONSTRAINT IF EXISTS events_cancellation_reason_check;
+
+ALTER TABLE events
+    ADD CONSTRAINT events_cancellation_reason_check CHECK (
+        cancellation_reason IS NULL
+        OR cancellation_reason IN (
+            'weather',
+            'insufficient_staff',
+            'unsafe_conditions',
+            'other'
+        )
+    );
+
+ALTER TABLE events
+    DROP CONSTRAINT IF EXISTS events_cancellation_state_check;
+
+ALTER TABLE events
+    ADD CONSTRAINT events_cancellation_state_check CHECK (
+        (cancellation_reason IS NULL AND cancelled_at IS NULL)
+        OR (cancellation_reason IS NOT NULL AND cancelled_at IS NOT NULL)
+    );

--- a/backend/models.py
+++ b/backend/models.py
@@ -47,6 +47,8 @@ class Event(Base):
     max_participants = Column(Integer, nullable=True)
     current_participants = Column(Integer, default=0)
     registration_deadline = Column(DateTime(timezone=True), nullable=True)
+    cancellation_reason = Column(String(50), nullable=True)
+    cancelled_at = Column(DateTime(timezone=True), nullable=True)
     distance_km = Column(Numeric(8, 2), nullable=True)
     is_public = Column(Boolean, default=True)
     created_at = Column(DateTime(timezone=True), default=_utcnow)

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -17,10 +17,12 @@ from database import get_db
 from models import Event, RSVP, Subscriber
 from routes.auth import get_current_admin
 from services.email import (
-    send_cancellation_email,
     send_broadcast_email,
+    send_cancellation_email,
+    send_event_cancellation_email,
     send_registrant_notification_email,
 )
+from services.event_cancellation import EventCancellationReason
 from services.event_counts import (
     count_confirmed_rsvps,
     get_available_spots,
@@ -52,6 +54,8 @@ REQUIRED_SCHEMA_COLUMNS = {
         "receives_registration_alerts",
     },
     "events": {
+        "cancellation_reason",
+        "cancelled_at",
         "distance_km",
     },
 }
@@ -76,6 +80,12 @@ class SyncOccurrencesResponse(BaseModel):
 
 class RideLeaderRequest(BaseModel):
     rsvp_id: int
+
+
+class CancelEventRequest(BaseModel):
+    """Event-wide cancellation request."""
+
+    reason: EventCancellationReason
 
 
 # ── Admin Schema Health ──────────────────────────────────────
@@ -224,6 +234,11 @@ def list_events(
                 event.registration_deadline.isoformat()
                 if event.registration_deadline else None
             ),
+            "cancellation_reason": event.cancellation_reason,
+            "cancelled_at": (
+                event.cancelled_at.isoformat()
+                if event.cancelled_at else None
+            ),
             "distance_km": float(event.distance_km) if event.distance_km is not None else None,
         })
 
@@ -278,6 +293,11 @@ def get_event_rsvps(
             "max_participants": event.max_participants,
             "current_participants": confirmed_count,
             "distance_km": float(event.distance_km) if event.distance_km is not None else None,
+            "cancellation_reason": event.cancellation_reason,
+            "cancelled_at": (
+                event.cancelled_at.isoformat()
+                if event.cancelled_at else None
+            ),
         },
         "rsvps": [
             {
@@ -561,6 +581,117 @@ def deactivate_ride_leader(
         "success": True,
         "message": "Ride leader removed and registration alerts stopped",
         "ride_leader_summary": serialize_ride_leader_snapshot(snapshot),
+    }
+
+
+# ── Admin Cancel Event ────────────────────────────────────────
+
+@router.post("/api/admin/events/{event_id}/cancel")
+def cancel_event(
+    event_id: int,
+    body: CancelEventRequest,
+    db: Session = Depends(get_db),
+    _admin: dict = Depends(get_current_admin),
+) -> dict:
+    """Cancel an event and notify every active registrant.
+
+    The event state is committed before email delivery. Confirmed and
+    waitlisted RSVPs remain unchanged so the registration record is preserved.
+
+    Args:
+        event_id: Database identifier of the event to cancel.
+        body: Validated cancellation reason.
+        db: Active database session.
+        _admin: Authenticated admin session.
+
+    Returns:
+        Cancellation state and email delivery summary.
+
+    Raises:
+        HTTPException: If the event is missing or already cancelled.
+    """
+    event = (
+        db.query(Event)
+        .filter(Event.id == event_id)
+        .with_for_update()
+        .first()
+    )
+    if not event:
+        raise HTTPException(
+            status_code=404,
+            detail={
+                "error_code": "EVENT_NOT_FOUND",
+                "message": "Event not found",
+            },
+        )
+
+    if event.cancelled_at is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error_code": "EVENT_ALREADY_CANCELLED",
+                "message": "Event is already cancelled",
+                "cancellation_reason": event.cancellation_reason,
+            },
+        )
+
+    reason = body.reason.value
+    event.cancellation_reason = reason
+    event.cancelled_at = datetime.now(timezone.utc)
+
+    try:
+        db.commit()
+        db.refresh(event)
+    except Exception:
+        db.rollback()
+        raise
+
+    rsvps = (
+        db.query(RSVP)
+        .filter(RSVP.event_id == event_id)
+        .order_by(RSVP.created_at)
+        .all()
+    )
+    sent = 0
+    skipped = 0
+    failed = 0
+
+    for rsvp in rsvps:
+        if rsvp.status == "cancelled":
+            skipped += 1
+            continue
+
+        try:
+            result = send_event_cancellation_email(
+                user_email=rsvp.email,
+                user_name=rsvp.name,
+                event_title=event.title,
+                event_date=event.event_date,
+                event_location=event.location,
+                cancellation_reason=reason,
+                event_slug=event.slug,
+            )
+            if result.get("status") == "error":
+                failed += 1
+            elif result.get("status") == "skipped":
+                skipped += 1
+            else:
+                sent += 1
+        except Exception as error:
+            logger.error(
+                "Event cancellation email failed for %s: %s",
+                rsvp.email,
+                error,
+                exc_info=True,
+            )
+            failed += 1
+
+    return {
+        "success": True,
+        "reason": reason,
+        "sent": sent,
+        "skipped": skipped,
+        "failed": failed,
     }
 
 

--- a/backend/routes/events.py
+++ b/backend/routes/events.py
@@ -32,6 +32,9 @@ class EventResponse(BaseModel):
     max_participants: Optional[int]
     current_participants: int
     registration_deadline: Optional[datetime]
+    cancellation_reason: Optional[str]
+    cancelled_at: Optional[datetime]
+    is_cancelled: bool
     available_spots: Optional[int]
     is_public: bool
 
@@ -70,6 +73,9 @@ def _event_response(db: Session, event: Event) -> dict:
         "max_participants": event.max_participants,
         "current_participants": confirmed_count,
         "registration_deadline": event.registration_deadline,
+        "cancellation_reason": event.cancellation_reason,
+        "cancelled_at": event.cancelled_at,
+        "is_cancelled": event.cancelled_at is not None,
         "available_spots": get_available_spots(
             event.max_participants,
             confirmed_count,
@@ -205,4 +211,4 @@ def create_event(
     db.commit()
     db.refresh(new_event)
 
-    return new_event
+    return _event_response(db, new_event)

--- a/backend/routes/rsvp.py
+++ b/backend/routes/rsvp.py
@@ -143,6 +143,16 @@ def create_rsvp(
             detail=f"Event with id {event_id} not found",
         )
 
+    if event.cancelled_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error_code": "EVENT_CANCELLED",
+                "message": "This event has been cancelled",
+                "cancellation_reason": event.cancellation_reason,
+            },
+        )
+
     # 2. 检查报名截止时间
     if (
         event.registration_deadline
@@ -304,6 +314,16 @@ def create_rsvp_v2(
     event = db.query(Event).filter(
         Event.slug == data.event_slug,
     ).with_for_update().first()
+
+    if event and event.cancelled_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "error_code": "EVENT_CANCELLED",
+                "message": "This event has been cancelled",
+                "cancellation_reason": event.cancellation_reason,
+            },
+        )
 
     event_date_dt = data.event_date
     if event_date_dt.tzinfo is None:

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 import resend
 from config import settings
+from services.event_cancellation import get_cancellation_reason_label
 
 logger = logging.getLogger(__name__)
 
@@ -219,6 +220,90 @@ def send_cancellation_email(
     except Exception as e:
         logger.error("Failed to send cancellation email: %s", e, exc_info=True)
         return {"status": "error", "message": str(e)}
+
+
+def send_event_cancellation_email(
+    user_email: str,
+    user_name: str,
+    event_title: str,
+    event_date: Optional[datetime] = None,
+    event_location: Optional[str] = None,
+    cancellation_reason: str = "other",
+    event_slug: str = "",
+) -> dict:
+    """Send an event-wide cancellation notice to a registered rider.
+
+    Args:
+        user_email: Recipient email address.
+        user_name: Recipient display name.
+        event_title: Cancelled event title.
+        event_date: Scheduled event date and time.
+        event_location: Scheduled meeting location.
+        cancellation_reason: Valid event cancellation reason code.
+        event_slug: Public event page slug.
+
+    Returns:
+        Resend response or a local skipped/error status dictionary.
+    """
+    if not settings.RESEND_API_KEY:
+        logger.debug(
+            "Skipping event cancellation email (no RESEND_API_KEY): %s",
+            user_email,
+        )
+        return {"status": "skipped", "reason": "no_api_key"}
+
+    safe_name = escape(user_name)
+    safe_title = escape(event_title)
+    safe_location = escape(event_location or "")
+    safe_reason = escape(
+        get_cancellation_reason_label(cancellation_reason),
+    )
+    date_str = event_date.strftime("%Y-%m-%d %H:%M") if event_date else ""
+    frontend_url = settings.PUBLIC_FRONTEND_URL or "https://www.across-cc.de"
+    event_link = (
+        f"{frontend_url}/en/events/{escape(event_slug, quote=True)}"
+        if event_slug
+        else frontend_url
+    )
+
+    html_body = (
+        '<div style="font-family:Arial,sans-serif;max-width:600px;">'
+        f'<h2 style="color:#C62828;">Event Cancelled: {safe_title}</h2>'
+        f"<p>Hello {safe_name},</p>"
+        "<p>The following event has been cancelled:</p>"
+        "<ul>"
+        f"<li><strong>Event:</strong> {safe_title}</li>"
+        + (f"<li><strong>Date:</strong> {date_str}</li>" if date_str else "")
+        + (
+            f"<li><strong>Location:</strong> {safe_location}</li>"
+            if safe_location
+            else ""
+        )
+        + f"<li><strong>Reason:</strong> {safe_reason}</li>"
+        + "</ul>"
+        + f'<p><a href="{event_link}">View event details</a></p>'
+        + "<p>— ACC ClubHub Team</p>"
+        + _CONTACT["en"]
+        + "</div>"
+    )
+
+    params = {
+        "from": "ACC ClubHub <noreply@events.across-cc.de>",
+        "to": [user_email],
+        "subject": f"Event Cancelled: {event_title}",
+        "html": html_body,
+    }
+
+    try:
+        return resend.Emails.send(params)
+    except Exception as error:
+        logger.error(
+            "Failed to send event cancellation email to %s: %s",
+            user_email,
+            error,
+            exc_info=True,
+        )
+        return {"status": "error", "message": str(error)}
 
 
 def send_broadcast_email(

--- a/backend/services/event_cancellation.py
+++ b/backend/services/event_cancellation.py
@@ -1,0 +1,42 @@
+"""Domain values for event-wide cancellation state."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EventCancellationReason(str, Enum):
+    """Allowed operational reasons for cancelling an event."""
+
+    WEATHER = "weather"
+    INSUFFICIENT_STAFF = "insufficient_staff"
+    UNSAFE_CONDITIONS = "unsafe_conditions"
+    OTHER = "other"
+
+
+_ENGLISH_REASON_LABELS = {
+    EventCancellationReason.WEATHER: "Adverse weather",
+    EventCancellationReason.INSUFFICIENT_STAFF: (
+        "Insufficient ride leaders or organisers"
+    ),
+    EventCancellationReason.UNSAFE_CONDITIONS: "Unsafe route conditions",
+    EventCancellationReason.OTHER: "Other operational reasons",
+}
+
+
+def get_cancellation_reason_label(
+    reason: EventCancellationReason | str,
+) -> str:
+    """Return the English label for an event cancellation reason.
+
+    Args:
+        reason: Stored cancellation reason code.
+
+    Returns:
+        Human-readable English reason label.
+
+    Raises:
+        ValueError: If the stored reason is not supported.
+    """
+    normalized_reason = EventCancellationReason(reason)
+    return _ENGLISH_REASON_LABELS[normalized_reason]

--- a/backend/tests/test_event_cancellation.py
+++ b/backend/tests/test_event_cancellation.py
@@ -1,0 +1,309 @@
+"""Tests for cancelling an event and notifying registered riders."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+from httpx import Response
+from models import RSVP, Event
+from sqlalchemy.orm import Session
+
+
+def _cancel_event(
+    client: TestClient,
+    event_id: int,
+    reason: str = "weather",
+) -> Response:
+    """Cancel one event through the admin endpoint."""
+    return client.post(
+        f"/api/admin/events/{event_id}/cancel",
+        json={"reason": reason},
+    )
+
+
+def _rsvp_payload(
+    event: Event,
+    email: str = "new@example.com",
+) -> dict[str, object]:
+    """Build a public RSVP payload for an existing event."""
+    return {
+        "email": email,
+        "name": "New Rider",
+        "privacy_accepted": True,
+        "event_slug": event.slug,
+        "event_title": event.title,
+        "event_location": event.location or "",
+        "event_date": event.event_date.isoformat(),
+        "event_type": event.event_type,
+        "max_participants": event.max_participants,
+        "lang": "en",
+    }
+
+
+class TestCancelEvent:
+    """Admin event cancellation persists state before sending email."""
+
+    def test_cancel_event_notifies_active_registrants(
+        self,
+        client: TestClient,
+        db: Session,
+        sample_event: Event,
+        confirmed_rsvp: RSVP,
+        waitlisted_rsvp: RSVP,
+    ) -> None:
+        cancelled_rsvp = RSVP(
+            event_id=sample_event.id,
+            email="cancelled@example.com",
+            name="Cancelled Rider",
+            status="cancelled",
+            privacy_accepted=True,
+        )
+        db.add(cancelled_rsvp)
+        db.commit()
+
+        with patch(
+            "routes.admin.send_event_cancellation_email",
+            return_value={"status": "sent"},
+        ) as mock_email:
+            response = _cancel_event(client, sample_event.id)
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "success": True,
+            "reason": "weather",
+            "sent": 3,
+            "skipped": 1,
+            "failed": 0,
+        }
+        db.refresh(sample_event)
+        assert sample_event.cancellation_reason == "weather"
+        assert sample_event.cancelled_at is not None
+        assert mock_email.call_count == 3
+        recipients = {
+            call.kwargs["user_email"]
+            for call in mock_email.call_args_list
+        }
+        assert recipients == {
+            confirmed_rsvp.email,
+            "bob@example.com",
+            waitlisted_rsvp.email,
+        }
+        assert all(
+            call.kwargs["cancellation_reason"] == "weather"
+            for call in mock_email.call_args_list
+        )
+
+    def test_cancel_event_email_failure_does_not_restore_event(
+        self,
+        client: TestClient,
+        db: Session,
+        sample_event: Event,
+        confirmed_rsvp: RSVP,
+    ) -> None:
+        with patch(
+            "routes.admin.send_event_cancellation_email",
+            side_effect=RuntimeError("email unavailable"),
+        ):
+            response = _cancel_event(client, sample_event.id)
+
+        assert response.status_code == 200
+        assert response.json()["failed"] == 1
+        db.refresh(sample_event)
+        assert sample_event.cancellation_reason == "weather"
+        assert confirmed_rsvp.status == "confirmed"
+
+    def test_cancel_event_rejects_unknown_reason(
+        self,
+        client: TestClient,
+        sample_event: Event,
+    ) -> None:
+        response = _cancel_event(client, sample_event.id, "rain<script>")
+
+        assert response.status_code == 422
+
+    def test_cancel_event_cannot_send_duplicate_batch(
+        self,
+        client: TestClient,
+        db: Session,
+        sample_event: Event,
+        confirmed_rsvp: RSVP,
+    ) -> None:
+        sample_event.cancellation_reason = "weather"
+        sample_event.cancelled_at = sample_event.updated_at
+        db.commit()
+
+        with patch(
+            "routes.admin.send_event_cancellation_email",
+        ) as mock_email:
+            response = _cancel_event(client, sample_event.id)
+
+        assert response.status_code == 409
+        assert response.json()["detail"]["error_code"] == (
+            "EVENT_ALREADY_CANCELLED"
+        )
+        mock_email.assert_not_called()
+
+
+class TestCancelledEventContract:
+    """Public and admin APIs expose one consistent cancellation state."""
+
+    def test_public_event_exposes_cancellation_state(
+        self,
+        client_no_auth: TestClient,
+        db: Session,
+        sample_event: Event,
+    ) -> None:
+        sample_event.cancellation_reason = "insufficient_staff"
+        sample_event.cancelled_at = sample_event.updated_at
+        db.commit()
+
+        response = client_no_auth.get(f"/api/events/{sample_event.slug}")
+
+        assert response.status_code == 200
+        assert response.json()["is_cancelled"] is True
+        assert response.json()["cancellation_reason"] == (
+            "insufficient_staff"
+        )
+        assert response.json()["cancelled_at"] is not None
+
+    def test_admin_event_detail_exposes_cancellation_state(
+        self,
+        client: TestClient,
+        db: Session,
+        sample_event: Event,
+    ) -> None:
+        sample_event.cancellation_reason = "unsafe_conditions"
+        sample_event.cancelled_at = sample_event.updated_at
+        db.commit()
+
+        response = client.get(
+            f"/api/admin/events/{sample_event.id}/rsvps",
+        )
+
+        assert response.status_code == 200
+        assert response.json()["event"]["cancellation_reason"] == (
+            "unsafe_conditions"
+        )
+        assert response.json()["event"]["cancelled_at"] is not None
+
+    def test_admin_event_list_exposes_cancellation_state(
+        self,
+        client: TestClient,
+        db: Session,
+        sample_event: Event,
+    ) -> None:
+        sample_event.cancellation_reason = "weather"
+        sample_event.cancelled_at = sample_event.updated_at
+        db.commit()
+
+        response = client.get("/api/admin/events")
+
+        assert response.status_code == 200
+        event_data = next(
+            item
+            for item in response.json()
+            if item["id"] == sample_event.id
+        )
+        assert event_data["cancellation_reason"] == "weather"
+        assert event_data["cancelled_at"] is not None
+
+    def test_occurrence_sync_preserves_cancellation_state(
+        self,
+        client: TestClient,
+        db: Session,
+        sample_event: Event,
+    ) -> None:
+        sample_event.cancellation_reason = "weather"
+        sample_event.cancelled_at = sample_event.updated_at
+        db.commit()
+
+        response = client.post(
+            "/api/admin/sync-occurrences",
+            json=[
+                {
+                    "slug": sample_event.slug,
+                    "title": "Updated title",
+                    "event_date": sample_event.event_date.isoformat(),
+                    "location": "Updated location",
+                },
+            ],
+        )
+
+        assert response.status_code == 200
+        db.refresh(sample_event)
+        assert sample_event.title == "Updated title"
+        assert sample_event.cancellation_reason == "weather"
+        assert sample_event.cancelled_at is not None
+
+    def test_cancelled_event_rejects_slug_based_registration(
+        self,
+        client_no_auth: TestClient,
+        db: Session,
+        sample_event: Event,
+    ) -> None:
+        sample_event.cancellation_reason = "weather"
+        sample_event.cancelled_at = sample_event.updated_at
+        db.commit()
+
+        response = client_no_auth.post(
+            "/api/rsvp",
+            json=_rsvp_payload(sample_event),
+        )
+
+        assert response.status_code == 409
+        assert response.json()["detail"]["error_code"] == (
+            "EVENT_CANCELLED"
+        )
+        db.refresh(sample_event)
+        assert sample_event.cancellation_reason == "weather"
+
+    def test_cancelled_event_rejects_id_based_registration(
+        self,
+        client_no_auth: TestClient,
+        db: Session,
+        sample_event: Event,
+    ) -> None:
+        sample_event.cancellation_reason = "other"
+        sample_event.cancelled_at = sample_event.updated_at
+        db.commit()
+
+        response = client_no_auth.post(
+            f"/api/events/{sample_event.id}/rsvp",
+            json={
+                "email": "new@example.com",
+                "name": "New Rider",
+                "privacy_accepted": True,
+                "lang": "en",
+            },
+        )
+
+        assert response.status_code == 409
+        assert response.json()["detail"]["error_code"] == (
+            "EVENT_CANCELLED"
+        )
+
+
+def test_event_cancellation_email_includes_reason() -> None:
+    """The cancellation email identifies the event-wide reason."""
+    from services.email import send_event_cancellation_email
+
+    mock_send = MagicMock(return_value={"id": "email-id"})
+    with (
+        patch("resend.Emails.send", mock_send),
+        patch("services.email.settings") as mock_settings,
+    ):
+        mock_settings.RESEND_API_KEY = "test-key"
+        send_event_cancellation_email(
+            user_email="rider@example.com",
+            user_name="Rider <script>",
+            event_title="Rain Ride",
+            event_date=None,
+            event_location="Munich",
+            cancellation_reason="weather",
+        )
+
+    params = mock_send.call_args.args[0]
+    assert params["subject"] == "Event Cancelled: Rain Ride"
+    assert "Adverse weather" in params["html"]
+    assert "Rider &lt;script&gt;" in params["html"]

--- a/frontend/src/components/EventRegistrationForm.css
+++ b/frontend/src/components/EventRegistrationForm.css
@@ -255,3 +255,10 @@
   text-align: center;
   margin: 1.5rem 0;
 }
+
+.event-cancelled-notice {
+  border-color: var(--color-accent);
+  background: var(--color-bg-secondary);
+  color: var(--color-text-main);
+  font-weight: 600;
+}

--- a/frontend/src/components/EventRegistrationForm.tsx
+++ b/frontend/src/components/EventRegistrationForm.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'preact/hooks';
 import type { VNode } from 'preact';
 import type { Locale } from '../lib/i18n';
 import { t } from '../lib/i18n';
+import { get_cancellation_notice } from '../lib/events/eventCancellation';
 
 interface EventRegistrationFormProps {
     eventSlug: string;
@@ -124,12 +125,27 @@ export function EventRegistrationForm({
             }
 
             if (!response.ok) {
-                if (data.detail?.includes('already registered')) {
+                const detail = data.detail;
+                if (detail?.error_code === 'EVENT_CANCELLED') {
+                    throw new Error(get_cancellation_notice(
+                        detail.cancellation_reason,
+                        lang,
+                    ));
+                } else if (
+                    typeof detail === 'string'
+                    && detail.includes('already registered')
+                ) {
                     throw new Error(t(lang, 'event.errorDuplicate'));
-                } else if (data.detail?.includes('deadline')) {
+                } else if (
+                    typeof detail === 'string'
+                    && detail.includes('deadline')
+                ) {
                     throw new Error(t(lang, 'event.errorDeadline'));
                 } else {
-                    throw new Error(data.detail || t(lang, 'event.errorServer'));
+                    const message = typeof detail === 'string'
+                        ? detail
+                        : detail?.message;
+                    throw new Error(message || t(lang, 'event.errorServer'));
                 }
             }
 

--- a/frontend/src/lib/admin/__tests__/events.test.ts
+++ b/frontend/src/lib/admin/__tests__/events.test.ts
@@ -26,6 +26,8 @@ function event(overrides: Partial<AdminEventRow>): AdminEventRow {
     spots_remaining: 20,
     db_id: 1,
     in_db: true,
+    cancellation_reason: null,
+    cancelled_at: null,
     ...overrides,
   };
 }
@@ -78,6 +80,10 @@ describe('admin event helpers', () => {
   });
 
   it('derives clear operational statuses', () => {
+    expect(getAdminEventStatus(event({
+      cancellation_reason: 'weather',
+      cancelled_at: '2026-04-24T08:00:00.000Z',
+    }), NOW).key).toBe('cancelled');
     expect(getAdminEventStatus(event({ db_id: null, in_db: false }), NOW).key)
       .toBe('not-synced');
     expect(getAdminEventStatus(event({ waitlist_count: 1 }), NOW).key)
@@ -147,6 +153,8 @@ describe('admin event helpers', () => {
       cancelled_count: 1,
       spots_remaining: 10,
       distance_km: 48.5,
+      cancellation_reason: 'insufficient_staff',
+      cancelled_at: '2026-04-24T08:00:00.000Z',
     })).toMatchObject({
       db_id: 42,
       slug: 'afterwork-ride-2026-04-30',
@@ -154,6 +162,7 @@ describe('admin event helpers', () => {
       confirmed_count: 5,
       distance_km: 48.5,
       in_db: true,
+      cancellation_reason: 'insufficient_staff',
     });
   });
 });

--- a/frontend/src/lib/admin/events.ts
+++ b/frontend/src/lib/admin/events.ts
@@ -15,6 +15,7 @@ export type AdminEventCategory = AdminEventType | 'all';
 
 export type AdminEventStatusKey =
   | 'open'
+  | 'cancelled'
   | 'full'
   | 'waitlist'
   | 'closed'
@@ -41,6 +42,8 @@ export type AdminEventRow = {
   db_id: number | null;
   in_db: boolean;
   distance_km?: number | null;
+  cancellation_reason: string | null;
+  cancelled_at: string | null;
 };
 
 export type AdminEventDbRow = {
@@ -57,6 +60,8 @@ export type AdminEventDbRow = {
   cancelled_count: number;
   spots_remaining: number | null;
   distance_km?: number | null;
+  cancellation_reason: string | null;
+  cancelled_at: string | null;
 };
 
 const EVENT_TYPE_LABELS: Record<AdminEventType, string> = {
@@ -113,6 +118,10 @@ export function getAdminEventStatus(
 ): AdminEventStatus {
   if (!event.in_db || event.db_id === null) {
     return { key: 'not-synced', label: 'Not Synced' };
+  }
+
+  if (event.cancelled_at !== null) {
+    return { key: 'cancelled', label: 'Cancelled' };
   }
 
   if (isPastEvent(event, now)) {
@@ -194,6 +203,8 @@ export function dbRowToAdminEvent(row: AdminEventDbRow): AdminEventRow | null {
     db_id: row.id,
     in_db: true,
     distance_km: row.distance_km ?? null,
+    cancellation_reason: row.cancellation_reason,
+    cancelled_at: row.cancelled_at,
   };
 }
 

--- a/frontend/src/lib/events/__tests__/eventCancellation.test.ts
+++ b/frontend/src/lib/events/__tests__/eventCancellation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  get_cancellation_notice,
+  type EventCancellationReason,
+} from '../eventCancellation';
+
+describe('event cancellation copy', () => {
+  const cases: Array<{
+    lang: 'zh' | 'en' | 'de';
+    reason: EventCancellationReason;
+    expected: string;
+  }> = [
+    { lang: 'zh', reason: 'weather', expected: '因天气原因' },
+    {
+      lang: 'en',
+      reason: 'insufficient_staff',
+      expected: 'insufficient ride leaders or organisers',
+    },
+    {
+      lang: 'de',
+      reason: 'unsafe_conditions',
+      expected: 'unsicherer Streckenbedingungen',
+    },
+  ];
+
+  for (const test_case of cases) {
+    it(`localizes ${test_case.reason} in ${test_case.lang}`, () => {
+      expect(
+        get_cancellation_notice(test_case.reason, test_case.lang),
+      ).toContain(test_case.expected);
+    });
+  }
+
+  it('uses neutral fallback copy for an unknown stored reason', () => {
+    expect(get_cancellation_notice('legacy-value', 'en')).toBe(
+      'This event has been cancelled. Registration is closed.',
+    );
+  });
+});

--- a/frontend/src/lib/events/eventCancellation.ts
+++ b/frontend/src/lib/events/eventCancellation.ts
@@ -1,0 +1,78 @@
+import type { Locale } from '../i18n';
+
+export type EventCancellationReason =
+  | 'weather'
+  | 'insufficient_staff'
+  | 'unsafe_conditions'
+  | 'other';
+
+export const EVENT_CANCELLATION_REASON_OPTIONS: Array<{
+  value: EventCancellationReason;
+  label: string;
+}> = [
+  { value: 'weather', label: 'Adverse weather' },
+  {
+    value: 'insufficient_staff',
+    label: 'Insufficient ride leaders or organisers',
+  },
+  { value: 'unsafe_conditions', label: 'Unsafe route conditions' },
+  { value: 'other', label: 'Other operational reasons' },
+];
+
+const CANCELLATION_NOTICES: Record<
+  EventCancellationReason,
+  Record<Locale, string>
+> = {
+  weather: {
+    zh: '本活动因天气原因取消，报名已停止。',
+    en: 'This event has been cancelled due to adverse weather. Registration is closed.',
+    de: 'Diese Veranstaltung wurde aufgrund ungünstiger Wetterbedingungen abgesagt. Die Anmeldung ist geschlossen.',
+  },
+  insufficient_staff: {
+    zh: '本活动因领骑或组织人员不足取消，报名已停止。',
+    en: 'This event has been cancelled due to insufficient ride leaders or organisers. Registration is closed.',
+    de: 'Diese Veranstaltung wurde aufgrund unzureichender Tourenleitung oder Organisation abgesagt. Die Anmeldung ist geschlossen.',
+  },
+  unsafe_conditions: {
+    zh: '本活动因路线条件不安全取消，报名已停止。',
+    en: 'This event has been cancelled due to unsafe route conditions. Registration is closed.',
+    de: 'Diese Veranstaltung wurde aufgrund unsicherer Streckenbedingungen abgesagt. Die Anmeldung ist geschlossen.',
+  },
+  other: {
+    zh: '本活动因其他运营原因取消，报名已停止。',
+    en: 'This event has been cancelled for other operational reasons. Registration is closed.',
+    de: 'Diese Veranstaltung wurde aus anderen organisatorischen Gründen abgesagt. Die Anmeldung ist geschlossen.',
+  },
+};
+
+const FALLBACK_NOTICES: Record<Locale, string> = {
+  zh: '本活动已取消，报名已停止。',
+  en: 'This event has been cancelled. Registration is closed.',
+  de: 'Diese Veranstaltung wurde abgesagt. Die Anmeldung ist geschlossen.',
+};
+
+export function is_event_cancellation_reason(
+  reason: string | null | undefined,
+): reason is EventCancellationReason {
+  return EVENT_CANCELLATION_REASON_OPTIONS.some(
+    (option) => option.value === reason,
+  );
+}
+
+export function get_cancellation_reason_label(
+  reason: string | null | undefined,
+): string {
+  return EVENT_CANCELLATION_REASON_OPTIONS.find(
+    (option) => option.value === reason,
+  )?.label ?? 'Unknown reason';
+}
+
+export function get_cancellation_notice(
+  reason: string | null | undefined,
+  lang: Locale,
+): string {
+  if (!is_event_cancellation_reason(reason)) {
+    return FALLBACK_NOTICES[lang] ?? FALLBACK_NOTICES.en;
+  }
+  return CANCELLATION_NOTICES[reason][lang] ?? CANCELLATION_NOTICES[reason].en;
+}

--- a/frontend/src/pages/[lang]/events/[slug].astro
+++ b/frontend/src/pages/[lang]/events/[slug].astro
@@ -7,6 +7,7 @@ import { getCollection, render } from 'astro:content';
 import { t, type Locale } from '../../../lib/i18n';
 import { getTodayAtMidnight } from '../../../lib/events/eventHelpers';
 import { resolveEventEntryBySlug } from '../../../lib/events/recurringEvents';
+import { get_cancellation_notice } from '../../../lib/events/eventCancellation';
 import { EventRegistrationForm } from '../../../components/EventRegistrationForm';
 import '../../../components/EventRegistrationForm.css';
 import SubscribeFloatingBanner from '../../../components/SubscribeFloatingBanner.astro';
@@ -27,6 +28,23 @@ const { Content } = await render(sourceEntry);
 
 // API URL from environment
 const apiUrl = import.meta.env.PUBLIC_API_URL || "https://acc-clubhub-events-ms.vercel.app";
+Astro.response.headers.set('Cache-Control', 'private, no-store');
+
+let cancellationReason: string | null = null;
+let isEventCancelled = false;
+try {
+  const operationalState = await fetch(
+    `${apiUrl}/api/events/${encodeURIComponent(entry.data.slug)}`,
+    { cache: 'no-store' },
+  );
+  if (operationalState.ok) {
+    const eventState = await operationalState.json();
+    isEventCancelled = eventState.is_cancelled === true;
+    cancellationReason = eventState.cancellation_reason ?? null;
+  }
+} catch {
+  // The RSVP API remains the authoritative cancellation guard if unavailable.
+}
 
 // Participant portal: check for token in query param
 let participantData = null;
@@ -61,7 +79,12 @@ const eventTypeLabel = entry.data.slug === 'hahntennjoch-epic-ride'
 
 const isPastEvent = new Date(entry.data.date) < getTodayAtMidnight();
 const registrationReopened = entry.data.registrationReopened === true;
-const showRegistrationForm = (!isPastEvent || registrationReopened) && !entry.data.registrationLink;
+const showRegistrationForm = (
+  (!isPastEvent || registrationReopened)
+  && !entry.data.registrationLink
+  && !isEventCancelled
+);
+const cancellationNotice = get_cancellation_notice(cancellationReason, lang);
 
 // Effective registration deadline: explicit value in frontmatter, or default to day before event at 22:00
 const rawDeadline = entry.data.registrationDeadline;
@@ -91,7 +114,7 @@ const isACCOfficialRide = entry.data.ACCOfficialRide === true;
   backLabel={t(lang, 'nav.events')}
 >
   <!-- Fallback: External registration link (if provided) -->
-  {entry.data.registrationLink && (
+  {entry.data.registrationLink && !isEventCancelled && (
     <a href={entry.data.registrationLink} target="_blank" rel="noopener" class="event-register-btn">
       {registrationLabels[lang] || registrationLabels.en} →
     </a>
@@ -134,7 +157,16 @@ const isACCOfficialRide = entry.data.ACCOfficialRide === true;
   )}
 
   <!-- Registration Form: inline compact, before comments -->
-  {isPastEvent && !registrationReopened && (
+  {isEventCancelled && (
+    <div
+      slot="before-comments"
+      class="event-ended-notice event-cancelled-notice"
+      role="status"
+    >
+      {cancellationNotice}
+    </div>
+  )}
+  {isPastEvent && !registrationReopened && !isEventCancelled && (
     <div slot="before-comments" class="event-ended-notice">
       {endedLabels[lang] ?? endedLabels.en}
     </div>

--- a/frontend/src/pages/dashboard/events/[id].astro
+++ b/frontend/src/pages/dashboard/events/[id].astro
@@ -2,6 +2,11 @@
 // dashboard/events/[id].astro — Admin event RSVP detail (SSR)
 export const prerender = false;
 
+import {
+  EVENT_CANCELLATION_REASON_OPTIONS,
+  get_cancellation_reason_label,
+} from '../../../lib/events/eventCancellation';
+
 const { id } = Astro.params;
 const apiUrl = import.meta.env.PUBLIC_API_URL || "https://acc-clubhub-events-ms.vercel.app";
 const isLocalPreview = import.meta.env.DEV
@@ -38,6 +43,8 @@ if (isLocalPreview) {
       max_participants: 15,
       current_participants: 2,
       distance_km: 48.5,
+      cancellation_reason: null,
+      cancelled_at: null,
     },
     rsvps: [
       {
@@ -223,6 +230,30 @@ function formatKm(value: number | null | undefined): string {
       .ride-summary-list dt { color: #57606a; }
       .ride-summary-list dd { margin: 0; font-weight: 600; color: #24292f; }
       .actions { display: flex; gap: 0.75rem; align-items: center; flex-wrap: wrap; }
+      .event-cancellation-action {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+      .event-cancellation-action select {
+        min-width: 240px;
+        padding: 0.4rem 0.7rem;
+        border: 1px solid #d0d7de;
+        border-radius: 6px;
+        background: white;
+        color: #24292f;
+        font-size: 0.85rem;
+      }
+      .event-cancelled-state {
+        padding: 0.65rem 0.85rem;
+        border: 1px solid #ff818266;
+        border-radius: 6px;
+        background: #ffebe9;
+        color: #cf222e;
+        font-size: 0.85rem;
+        font-weight: 600;
+      }
       .action-btn {
         display: inline-block;
         padding: 0.4rem 0.9rem;
@@ -434,6 +465,13 @@ function formatKm(value: number | null | undefined): string {
               <span>👥 {eventData.event.current_participants}/{eventData.event.max_participants || "∞"}</span>
               <span>📏 {formatKm(eventData.event.distance_km)}</span>
             </div>
+            {eventData.event.cancelled_at && (
+              <div class="event-cancelled-state">
+                Cancelled — {get_cancellation_reason_label(
+                  eventData.event.cancellation_reason,
+                )} · {formatDate(eventData.event.cancelled_at)}
+              </div>
+            )}
           </div>
 
           <div class="summary-bar">
@@ -525,6 +563,33 @@ function formatKm(value: number | null | undefined): string {
             </button>
             <span id="notify-status"></span>
           </div>
+
+          <div style="height: 1rem;"></div>
+
+          {!eventData.event.cancelled_at && (
+            <div class="event-cancellation-action">
+              <select
+                id="event-cancellation-reason"
+                aria-label="Select event cancellation reason"
+              >
+                <option value="">Select cancellation reason</option>
+                {EVENT_CANCELLATION_REASON_OPTIONS.map((option) => (
+                  <option value={option.value}>{option.label}</option>
+                ))}
+              </select>
+              <button
+                type="button"
+                class="action-btn secondary"
+                id="cancel-event-btn"
+                data-recipient-count={
+                  eventData.summary.confirmed + eventData.summary.waitlist
+                }
+              >
+                Cancel event &amp; notify registrants
+              </button>
+              <span id="cancel-event-status"></span>
+            </div>
+          )}
 
           <div style="height: 1.5rem;"></div>
 
@@ -1014,6 +1079,62 @@ function formatKm(value: number | null | undefined): string {
           btn.disabled = false;
         }
       });
+
+      document.getElementById("cancel-event-btn")?.addEventListener(
+        "click",
+        async () => {
+          const button = document.getElementById("cancel-event-btn");
+          const select = document.getElementById("event-cancellation-reason");
+          const status = document.getElementById("cancel-event-status");
+          const reason = select?.value ?? "";
+          const reasonLabel = select?.selectedOptions[0]?.textContent ?? reason;
+          const recipientCount = button?.dataset.recipientCount ?? "0";
+
+          if (!reason) {
+            status.textContent = "Select a cancellation reason.";
+            status.style.color = "#cf222e";
+            select?.focus();
+            return;
+          }
+
+          const confirmed = await confirmAction({
+            title: "Cancel event",
+            message: `Cancel this event due to ${reasonLabel.toLowerCase()} and send cancellation email to all ${recipientCount} confirmed and waitlisted registrants?`,
+            confirmLabel: "Cancel event & send email",
+            danger: true,
+          });
+          if (!confirmed) return;
+
+          button.disabled = true;
+          select.disabled = true;
+          status.textContent = "Cancelling event and sending email…";
+          status.style.color = "#57606a";
+
+          try {
+            const response = await fetch(`/api/admin/events/${id}/cancel`, {
+              method: "POST",
+              credentials: "include",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ reason }),
+            });
+            const data = await response.json();
+            if (!response.ok) {
+              const detail = typeof data.detail === "object"
+                ? data.detail.message
+                : data.detail;
+              throw new Error(detail || `${response.status}`);
+            }
+            status.textContent = `Sent: ${data.sent} · Skipped: ${data.skipped} · Failed: ${data.failed}`;
+            status.style.color = data.failed > 0 ? "#9a6700" : "#1a7f37";
+            window.setTimeout(() => window.location.reload(), 1500);
+          } catch (error) {
+            status.textContent = `Failed: ${error.message}`;
+            status.style.color = "#cf222e";
+            button.disabled = false;
+            select.disabled = false;
+          }
+        },
+      );
     </script>
   </body>
 </html>

--- a/frontend/src/pages/dashboard/events/index.astro
+++ b/frontend/src/pages/dashboard/events/index.astro
@@ -189,6 +189,8 @@ const currentRows: AdminEventRow[] = zhEvents.map((e) => {
     db_id: stats?.id ?? null,
     in_db: !!stats,
     distance_km: stats?.distance_km ?? (e.data.distanceKm ?? null),
+    cancellation_reason: stats?.cancellation_reason ?? null,
+    cancelled_at: stats?.cancelled_at ?? null,
   };
 });
 const allMerged = mergeAdminEventRows(currentRows, dbRows, now);
@@ -319,6 +321,7 @@ function getCategoryUrl(category: AdminEventCategory): string {
         font-weight: 700;
       }
       .status-open { background: #dafbe1; color: #1a7f37; }
+      .status-cancelled { background: #ffebe9; color: #cf222e; }
       .status-full,
       .status-waitlist { background: #fff8c5; color: #9a6700; }
       .status-closed,

--- a/progress.md
+++ b/progress.md
@@ -11,6 +11,14 @@
 
 ## Recent Updates
 
+- [X] **Event Cancellation Notifications** (2026-08-25) — branch `phase-4/event-cancellation`
+  - [X] Added an Admin Events action with a required cancellation reason and a recipient-count confirmation dialog.
+  - [X] Persisted event-wide cancellation state separately from RSVP status and blocked both public registration endpoints after cancellation.
+  - [X] Sent an English cancellation email to every confirmed and waitlisted registrant while skipping already-cancelled RSVPs.
+  - [X] Updated public zh/en/de event pages from the live operational API without a frontend rebuild, hiding internal and external registration controls and showing the localized reason.
+  - [X] Added migration `013_add_event_cancellation.sql` and schema-health coverage for the cancellation columns.
+  - [X] Verified 11 focused backend tests, 52 frontend tests, `npm run check` (0 errors), `npm run build`, and local SSR output for both Admin controls and a weather-cancelled Chinese event page. The full backend suite remains at 160 passed plus the known historical-alias baseline failure.
+
 - [X] **Eaglet Program Komoot Route Embeds** (2026-08-15)
   - [X] Embedded the Komoot map, elevation profile, and route details for all three Eaglet sessions across zh/en/de event pages.
   - [X] Reused each session's share-token route and the existing Afterwork event embed structure.


### PR DESCRIPTION
## Summary

- add an Admin Events action that requires a cancellation reason and confirms the confirmed + waitlisted recipient count
- persist event-wide cancellation state separately from RSVP status and send cancellation emails to active registrants
- block both public RSVP endpoints after cancellation
- update zh/en/de event pages from the live operational API, hide registration controls, and show the localized cancellation reason without a frontend rebuild

## Database migration gate

Do not merge before the production database migration is applied.

1. Confirm CI is green.
2. Run `backend/migrations/013_add_event_cancellation.sql` in Neon.
3. Verify the migration succeeded.
4. Merge and deploy.
5. Confirm `/api/admin/health/schema` returns `ok: true`.

The migration is additive and backward-compatible with the currently deployed code. The new backend expects the two columns to exist.

## Verification

- backend cancellation tests: 11 passed
- frontend Vitest suite: 52 passed
- `npm run check`: 0 errors
- `npm run build`: passed
- local SSR smoke test: cancelled Chinese event page showed the weather reason and omitted the registration container; Admin event detail rendered the reason selector and cancellation action
- full backend suite: 160 passed, with the existing unrelated historical ride-leader alias assertion still failing
