### PR TITLE
fix(events): show cancellation time in Munich

### DIFF
--- a/frontend/src/lib/events/__tests__/eventCancellation.test.ts
+++ b/frontend/src/lib/events/__tests__/eventCancellation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  format_cancellation_timestamp,
   get_cancellation_notice,
   type EventCancellationReason,
 } from '../eventCancellation';
@@ -35,5 +36,17 @@ describe('event cancellation copy', () => {
     expect(get_cancellation_notice('legacy-value', 'en')).toBe(
       'This event has been cancelled. Registration is closed.',
     );
+  });
+
+  it('formats summer cancellation timestamps in Munich time', () => {
+    expect(
+      format_cancellation_timestamp('2026-08-25T14:10:35.581465Z'),
+    ).toBe('25 Aug 2026, 16:10');
+  });
+
+  it('formats winter cancellation timestamps in Munich time', () => {
+    expect(
+      format_cancellation_timestamp('2026-01-25T14:10:35.581465Z'),
+    ).toBe('25 Jan 2026, 15:10');
   });
 });

--- a/frontend/src/lib/events/eventCancellation.ts
+++ b/frontend/src/lib/events/eventCancellation.ts
@@ -76,3 +76,21 @@ export function get_cancellation_notice(
   }
   return CANCELLATION_NOTICES[reason][lang] ?? CANCELLATION_NOTICES[reason].en;
 }
+
+export function format_cancellation_timestamp(
+  value: string | null | undefined,
+): string {
+  if (!value) return '—';
+
+  const timestamp = new Date(value);
+  if (Number.isNaN(timestamp.valueOf())) return value;
+
+  return timestamp.toLocaleString('en-GB', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Europe/Berlin',
+  });
+}

--- a/frontend/src/pages/dashboard/events/[id].astro
+++ b/frontend/src/pages/dashboard/events/[id].astro
@@ -4,6 +4,7 @@ export const prerender = false;
 
 import {
   EVENT_CANCELLATION_REASON_OPTIONS,
+  format_cancellation_timestamp,
   get_cancellation_reason_label,
 } from '../../../lib/events/eventCancellation';
 
@@ -469,7 +470,9 @@ function formatKm(value: number | null | undefined): string {
               <div class="event-cancelled-state">
                 Cancelled — {get_cancellation_reason_label(
                   eventData.event.cancellation_reason,
-                )} · {formatDate(eventData.event.cancelled_at)}
+                )} · {format_cancellation_timestamp(
+                  eventData.event.cancelled_at,
+                )}
               </div>
             )}
           </div>

--- a/progress.md
+++ b/progress.md
@@ -16,8 +16,9 @@
   - [X] Persisted event-wide cancellation state separately from RSVP status and blocked both public registration endpoints after cancellation.
   - [X] Sent an English cancellation email to every confirmed and waitlisted registrant while skipping already-cancelled RSVPs.
   - [X] Updated public zh/en/de event pages from the live operational API without a frontend rebuild, hiding internal and external registration controls and showing the localized reason.
+  - [X] Rendered cancellation timestamps in `Europe/Berlin`, including automatic CET/CEST daylight-saving conversion on Vercel SSR.
   - [X] Added migration `013_add_event_cancellation.sql` and schema-health coverage for the cancellation columns.
-  - [X] Verified 11 focused backend tests, 52 frontend tests, `npm run check` (0 errors), `npm run build`, and local SSR output for both Admin controls and a weather-cancelled Chinese event page. The full backend suite remains at 160 passed plus the known historical-alias baseline failure.
+  - [X] Verified 11 focused backend tests, 54 frontend tests (including summer and winter timezone cases under `TZ=UTC`), `npm run check` (0 errors), `npm run build`, and local SSR output for both Admin controls and a weather-cancelled Chinese event page. The full backend suite remains at 160 passed plus the known historical-alias baseline failure.
 
 - [X] **Eaglet Program Komoot Route Embeds** (2026-08-15)
   - [X] Embedded the Komoot map, elevation profile, and route details for all three Eaglet sessions across zh/en/de event pages.


### PR DESCRIPTION
## Summary

- render Admin cancellation timestamps explicitly in `Europe/Berlin`
- preserve the existing event start-time display behavior
- cover both CEST (summer) and CET (winter) conversion

## Root cause

The backend correctly stored the cancellation instant in UTC. Vercel SSR formatted it without an explicit time zone, so a cancellation at 16:10 Munich time appeared as 14:10.

## Verification

- `TZ=UTC npm run test`: 54 passed
- `npm run check`: 0 errors
- `npm run build`: passed
